### PR TITLE
add mine lazy routing to prevent guess-parser error

### DIFF
--- a/projects/sampleBlog/src/app/app-routing.module.ts
+++ b/projects/sampleBlog/src/app/app-routing.module.ts
@@ -22,6 +22,7 @@ const routes: Routes = [
     loadChildren: () => import('./user/user.module').then(m => m.UserModule),
   },
   {path: 'demo', loadChildren: () => import('./demo/demo.module').then(m => m.DemoModule)},
+  {path: 'mine', loadChildren: () => import('./mine/mine.module').then(m => m.MineModule)},
 ];
 
 @NgModule({


### PR DESCRIPTION
When leave mine module alone, guess-parser will produce the following error.

```
Error: Multiple root routing modules found 
/scully/projects/sampleBlog/src/app/app.module.ts,
/scully/projects/sampleBlog/src/app/mine/mine-routing.module.ts
    at findRootModule (/scully/node_modules/guess-parser/dist/guess-parser/index.js:432:15)
    at Object.exports.parseRoutes [as parseAngularRoutes] (/scully/node_modules/guess-parser/dist/guess-parser/index.js:596:31)
    at Object.exports.traverseAppRoutes (/scully/scully/bin/routerPlugins/traverseAppRoutesPlugin.js:7:39)
    at Object.staticServer (/scully/scully/bin/utils/staticServer.js:13:56)
    at startStaticServer (/scully/scully/bin/scully.js:149:20)
    at Timeout.setTimeout [as _onTimeout] (/scully/scully/bin/scully.js:157:9)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```