### PR TITLE
More and improved samples and error messages

### DIFF
--- a/blog/page-1.md
+++ b/blog/page-1.md
@@ -2,6 +2,7 @@
 title: My first page
 author: Sander Elias
 publish date: 2019-11-26
+description: This is the first demo page in this sample.
 ---
 # Page 1
 
@@ -14,7 +15,7 @@ publish date: 2019-11-26
 Related information [page-2](/blog/page-2)
 
 
-[site-map](/static)
+[site-map](/home)
 
 <!-- 06 231 449 78 Dave Vera, -->
 

--- a/blog/page-2.md
+++ b/blog/page-2.md
@@ -1,3 +1,9 @@
+---
+title: My second page
+author: Sander Elias
+publish date: 2019-11-27
+description: This is the second demo page in this sample.
+---
 # Page 2
 
 ## its a wild world after all
@@ -6,7 +12,7 @@
   console.log('amazing')
 ```
 
-Related information [page-1](/blog/page-1)
+Related information [page-3](/blog/page-3)
 
-[site-map](/static)
+[site-map](/home)
 

--- a/blog/page-3.md
+++ b/blog/page-3.md
@@ -1,0 +1,908 @@
+---
+title: My third page
+author: Sander Elias
+publish date: 2019-11-28
+description: At this point, I should write something different in here.
+---
+# Page 2
+
+## its a wild world after all
+
+```typescript
+  console.log('amazing')
+```
+
+Related information [page-1](/blog/page-1)
+
+[site-map](/home)
+
+The Project Gutenberg EBook of Don't Think About It, by William W. Stuart
+
+This eBook is for the use of anyone anywhere in the United States and most
+other parts of the world at no cost and with almost no restrictions
+whatsoever.  You may copy it, give it away or re-use it under the terms of
+the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org.  If you are not located in the United States, you'll have
+to check the laws of the country where you are located before using this ebook.
+
+Title: Don't Think About It
+
+Author: William W. Stuart
+
+Release Date: December 16, 2019 [EBook #60935]
+
+Language: English
+
+Character set encoding: ASCII
+
+*** START OF THIS PROJECT GUTENBERG EBOOK DON'T THINK ABOUT IT ***
+
+
+
+
+Produced by Greg Weeks, Mary Meehan and the Online
+Distributed Proofreading Team at http://www.pgdp.net
+
+
+
+
+
+
+
+
+
+                    _It isn't much of a secret, but
+                 it's the only one. The trick is ..._
+
+                         Don't Think About It
+
+                         By WILLIAM W. STUART
+
+           [Transcriber's Note: This etext was produced from
+             Worlds of If Science Fiction, November 1960.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+
+Tommy wasn't really a timid child. Sometimes he didn't understand
+things and was puzzled. More often, grown-ups couldn't or wouldn't
+understand things that were perfectly clear to him and he was more
+puzzled. Occasionally such things worried and even upset him a little.
+Then Momma and sometimes Daddy would translate bafflement into silly
+adult terms and think that he was afraid.
+
+It was that way about the hole in the closet when Tommy was just a bit
+over three. Tommy wasn't really afraid. Mr. Bear was afraid and the
+thing did puzzle Tommy. So he asked about it, but he never did get any
+sensible or satisfactory answers, and that did worry and perhaps even
+upset him a little.
+
+But he wasn't afraid, even before Daddy finally told him, "Now, Tommy,
+boy. Don't think about it and it won't scare you. Really, there is
+nothing there to hurt you, if you just don't think about it. So don't
+you think about it any more--there's Daddy's big boy."
+
+This certainly was not any sort of explanation. But still Tommy did try
+hard not to think about it, as Daddy said. And now he really doesn't
+think about it at all any more. Or about Aunt Martha, either.
+
+The hole was in the closet in Tommy's room. Tommy and Momma and Daddy
+lived in a not very big, not very new frame house on the edge of the
+city and Aunt Martha lived with them. Tommy didn't--at least not yet,
+although there were promises--have any brothers or sisters. But he
+did have his own room and a family of his own, too. It was the extra
+bedroom and it had a closet that was cramped and with no light. Tommy
+liked his room. It was small, with a small bed, and it belonged to
+him, along with his family of Mr. Bear and Old Rabbit and Kokey Koala.
+It was also in easy crying range of Momma and Daddy's room and Aunt
+Martha's room, so if Mr. Bear, who was the timid one, got frightened in
+the night, Tommy could cry--purely in Mr. Bear's behalf--to bring help.
+Or at least company.
+
+Tommy and his family all liked the closet well enough too, except for
+the shelf that was out of reach even from the "don't climb" stool. The
+closet was good to hide in or play bear cave or rabbit hole and fine
+for finding missing toys after Momma had a spell of playing cleaning
+house.
+
+The day Tommy found the hole in the closet was the week after his
+third birthday. Daddy was at work. Momma was out shopping. It was a
+rainy afternoon. Aunt Martha was sitting with Tommy and the afternoon
+television.
+
+       *       *       *       *       *
+
+He was in his room with his family and they all agreed as soon as they
+heard the television coming on strong that it would be a very poor
+afternoon to waste on a nap. Besides, Mr. Bear's feelings had been
+hurt by having been somewhat left out of things recently in favor of
+new birthday presents, now largely broken or tiresome. To make it up
+to him, Tommy and Old Rabbit and Kokey all agreed to play bear cave in
+the closet. It was a nice game and going well enough, except for some
+grumbling from Kokey Koala, who always wanted to argue and claimed that
+bears lived in trees, not caves.
+
+But then--and it was Mr. Bear's fault for wanting it darker, so he
+could hibernate--the closet door shut tight. That didn't seem so
+serious at first. It would only mean a scolding for being out of bed
+when Aunt Martha would come to open it after Tommy hollered loud
+enough. And then there was the hole in the closet, back in the corner
+next to the broken drum. They all saw it and they heard the Ugly Thing
+talking or thinking at them. It stretched out a part of itself at Mr.
+Bear, who was the closest.
+
+It didn't grab Mr. Bear, but he was terrified just the same. And none
+of them liked it. They didn't like it at all. The Ugly Thing couldn't
+come out of the hole because the hole wasn't big enough yet, but it
+tried and it was making the hole bigger. And it kept thinking at them,
+red thoughts, and hungry, as it tore at the edges of the hole. The
+family all looked to Tommy, so Tommy cried and yelled.
+
+Finally Aunt Martha heard him and came to open the door. Then the
+afternoon sunlight streamed across the floor into the closet and the
+ugly red thoughts from the Thing pulled back, far back, so you could
+barely notice them, and you couldn't see the hole any more, even though
+you knew it was still there. At least Tommy and Mr. Bear and Old Rabbit
+and Kokey Koala knew.
+
+After she opened the closet door and carried Tommy from the closet to
+the living room, Aunt Martha scolded. She wasn't really mad because
+she had waited until a commercial interrupted her television program
+before answering the cries from the closet. But she scolded because she
+was Aunt Martha and scolding was what Aunt Martha did. A really good
+cry, even one worked up strictly as a service for a companion, takes a
+little time to turn off. Then, after a few settling gulps, Tommy tried
+to explain.
+
+"Auntie. Aunt Martha, there's a hole in the cave--in the closet--and
+there's a Thing inside of it."
+
+He looked at Mr. Bear whom he was holding by one foot and at Kokey,
+dropped by Aunt Martha on the sofa, for confirmation. Then, quickly, he
+wriggled down from Auntie's lap. Old Rabbit!
+
+       *       *       *       *       *
+
+Bravely, Tommy ran to the closet and was relieved. The door was open
+and, in the gray afternoon light, the hole was still not to be seen.
+Old Rabbit, who always had a bad temper, was annoyed and snappish at
+having been left behind. But he was there and all right. Tommy rescued
+him and ran back to Aunt Martha.
+
+"It was hungry," he continued his explanation.
+
+Aunt Martha, as always, was difficult. "Who is hungry? You shouldn't be
+hungry, Tommy. You just had your lunch an hour ago. Do you want a glass
+of milk?"
+
+"Not me hungry." Tommy was impatient. Aunt Martha never seemed able to
+grasp any idea more complex than a glass of milk or wet pants. Little
+boys, in her mind, nearly always either wanted the one or had the
+other. Such things she could and did attend to with a virtuous sense of
+duty done. But anything else was beyond her.
+
+"Tommy! Are your pants wet?"
+
+Tommy sighed in resignation and wet his pants. It was the only thing
+to do. Otherwise Auntie would fuss and fume, accomplishing nothing,
+understanding nothing, for the rest of the afternoon.
+
+Ten minutes later, in dry pants, he finished an unwanted glass of milk.
+Aunt Martha, conscience appeased, returned to soap opera. Tommy and his
+family, nap safely forgotten, played away the afternoon--but not in the
+closet or even, as was usual on rainy days, in Tommy's room. Instead,
+finding Daddy's old briefcase full of papers, they played office in the
+family room, with Old Rabbit grumbling about having to be Miss Wicksey,
+who drove the electric typewriter in Daddy's office.
+
+Momma and Daddy came home together at a bit after five. Tommy took his
+scolding about messing up Daddy's papers in good part. He had expected
+it. But Aunt Martha was angry about the scolding she got for letting
+him, mild though it was.
+
+In retaliation, she said, "Tommy, you were a naughty, naughty boy.
+And for being so naughty you must take your big bear and your rabbit
+and the little bear or whatever the thing is and put them away in the
+closet. And leave them there till tomorrow."
+
+"No! No, no, no, I won't! It isn't fair. They weren't bad. And the Ugly
+Thing is in the hole and it might come out and it's hungry and--and my
+family is all afraid."
+
+"Tommy!" Aunt Martha's voice was sharp. "You stop that nonsense and put
+your toys--"
+
+"Wait. Wait up now," said Daddy, who also lived in the grown-up world,
+but who sometimes tried to understand things. "What is this about a
+hole in the closet? What about something being hungry?"
+
+"That's all," said Tommy. "The Ugly Thing in the hole in the closet. It
+_is_ hungry."
+
+There was more to it than that, of course, but how could a thing like
+that be explained through a wall of grown, closed minds? There was
+the hole in the closet. You couldn't exactly see it. You could only
+sort of feel seeing it and the hairy Thing--at least it seemed hairy
+and shapeless, or having many different shapes and a mouth and sharp
+teeth--and it had reached out with something and touched Mr. Bear and
+would have eaten him too, if he had blood. But then it had pulled back
+from Mr. Bear and red hunger thoughts came stronger and stronger. Even
+now, stretching out from the hole where it was hidden there in the
+closet, Tommy could feel the reaching, greedy thoughts. But he couldn't
+explain all that.
+
+"There is a hole in the closet," Tommy said again.
+
+       *       *       *       *       *
+
+But he knew that not even Daddy would understand. Of course Momma
+wouldn't. Not Momma, who was loving but very busy and just sat so
+often, dreaming or listening to baby sister that they said was in her
+stomach, so big and fat now as to leave little lap room. Momma was
+too occupied looking inward to look out much at Tommy. Daddy, to give
+him credit, was nearly always willing to look, but there were so many
+things he couldn't see. Still Tommy had to try.
+
+"The Ugly Thing in the hole. It wants something to eat."
+
+"Oh, Tommy! Such horrible nonsense!" That was Momma. She wasn't even
+going to think about it. It is a question sometimes whether baby
+sisters are worth all the bother and trouble.
+
+"Now, Tommy." Daddy was being helpful. "You say there is a hole in your
+closet? And that there is something in the hole?"
+
+"Well-ll. Sort of." Really, the Ugly Thing wasn't so much in the hole
+as on the other side of it. But that was close enough.
+
+"All right then, Tommy. Suppose you show it to me."
+
+"What?"
+
+"Show me the hole, Tommy."
+
+"Now?"
+
+"Yes."
+
+"The hole in the closet?"
+
+"Tommy!"
+
+"Yes, Daddy." This wasn't going to work out to anything good and Tommy
+didn't want to go back to the closet and close the closet door anyway.
+The Thing didn't eat Mr. Bear because Mr. Bear didn't have blood. But
+Daddy had and ... "Tommy!"
+
+They went to the closet. At least, if he was risking a Daddy, Tommy
+thought, he was protecting Mr. Bear and the others.
+
+"Now where is this hole, Tommy?"
+
+"Over there by the corner." Tommy pointed.
+
+Daddy went into the closet to look. Tommy started to close the door. In
+the black dark, Daddy would see what Tommy meant about the Thing in the
+hole. From the outside, Tommy started to close the door. It was a small
+closet and hardly big enough for both of them.
+
+"Tommy! What are you trying to do? Open that door."
+
+"But--" After all, the hole wasn't there, or scarcely seemed to be
+there, except in the dark.
+
+"Open it up wider. Hm-m. I believe I do see. Wait till I get my
+lighter.... Say, by George, I believe you're right. There _is_ a little
+hole there. Looks like a mouse hole."
+
+There it was, as Tommy might have known. Grown-ups will always avoid
+seeing the important things. Of course there was a mouse hole there,
+the home of the little old Mr. Mouse with the wiggly nose and the gray
+whiskers. He had been nice. But he wasn't there any more and Tommy had
+a pretty clear idea of what had happened to him. That poor little old
+Mr. Mouse had had blood.
+
+"But, Daddy--"
+
+It was hopeless. "Dorrie! Martha!" Daddy's hunting instinct was
+aroused. "Have we got a mouse trap? Any cheese? There is a hole in that
+closet, a little old mouse hole and I'm going to--"
+
+Well, perhaps this would be better than if he hadn't found anything.
+
+Tommy followed Daddy about as he finally located a mouse trap. No
+cheese? He cut a little piece of meat for bait. Of course Tommy knew no
+trap would catch the Ugly Thing.
+
+"What in the world happened to my lighter?" Daddy wanted to know. Tommy
+didn't answer that. But at least everybody, even Aunt Martha, had
+forgotten about shutting Tommy's family up in the closet. For now that
+was enough.
+
+But later, after supper, after bath, after the shooting picture on the
+TV, it was time for bed.
+
+"Daddy?"
+
+"Get on to bed now, son. Past bedtime. Hop to it."
+
+"Daddy, I want to sleep with you and Momma tonight."
+
+       *       *       *       *       *
+
+Well, it was a mighty dark night. The afternoon rain had built up into
+a real storm. Mr. Bear was terrified. Kokey was scared and even tough
+Old Rabbit didn't want to sleep in Tommy's room with the Ugly Thing in
+the hole so hungry and waiting to rip its way out of the hole when it
+got dark enough--and only the street light outside the room to keep
+away the dark because they would never let Tommy keep his light on at
+night.
+
+"My family and me don't want to sleep in my room tonight."
+
+"Now, Tommy, just because it's a little stormy--Daddy's big boy isn't
+afraid of a little wind and rain?"
+
+"I'm not afraid, Daddy. It's my family. You know how families are. You
+always say about Momma--"
+
+"Never mind that now. To bed. Your own bed."
+
+"But Daddy, there's the Ugly Thing in the hole! And it's hungry!"
+
+"The mouse?"
+
+Daddy went to look at his trap, switching on the light in Tommy's room.
+He came back in a minute.
+
+"The little devil!"
+
+Did Daddy know? No.
+
+"The little devil got away with the bait, clean as a whistle. Only a
+little plaster dust or something left in the trap where I put the meat."
+
+Mr. Bear shivered. "Now don't be foolish, Bear. You don't _have_ blood.
+The Ugly Thing won't get you," Tommy told him softly. But Mr. Bear
+wouldn't listen. He was a cry-baby, a scaredy-cat. But to tell the
+truth--the real, honest truth--the whole family and even Tommy didn't
+feel too good about it.
+
+"Tommy? What was that you were saying?"
+
+"Daddy! I wanna sleep with you and Momma. Me and my family. We're
+scared of that Thing." Tommy knew it was no less than his duty to
+protect them all.
+
+"Oh, now, Tommy! You don't mean to say you're afraid of a little old
+mouse? A big boy like you?"
+
+"Well, Mr. Bear is--I don't--Daddy! It is there, honest it is, in that
+hole and it's hungry and it'll come out in the dark and--"
+
+"Tommy! A little mouse! Get on into your room now and no more argument."
+
+Tommy's face began to crumple. If he had to, he would fight this one
+out all the way--tears, tantrum, kick, scream, gasp, hold his breath
+and turn blue--
+
+"Now, now, Tommy-boy." Daddy did mean well and sometimes he was even
+right and so Tommy always did try to do what Daddy said. "Tommy, you
+mustn't let things like that bother you. If we can't catch the little
+mouse, forget it. There's nothing more we can do, so just don't think
+about it. You see?"
+
+Sniff. "No."
+
+"Don't think about it, that's all. There is nothing there that can hurt
+you, if you just don't think about it. So don't think about it--that's
+Daddy's big boy."
+
+"Well-ll.... And then can we sleep with you and Momma?"
+
+Aunt Martha rang in her nickel's worth. "A boy ought to be ashamed to
+be afraid of a little mouse."
+
+"It's not--"
+
+"Not what?"
+
+"Uh--it's Mr. Bear that's afraid. Of the--"
+
+"And you just stop that nonsense about those ridiculous stuffed
+animals, you hear me? Nobody should make such a fuss about a little
+mouse."
+
+"Momma does. Momma!" Tommy let two fat tears trickle down his cheeks, a
+warning, but he meant them too. "Momma-a-a, can't we--"
+
+"All right, all right! Stop this stupid wrangling! You know how it
+gets on my nerves. For goodness' sake, let him sleep with us tonight.
+Anyway, _I_ don't blame him. I wouldn't sleep a wink in the same room
+with a mouse. Be sure you shut our door tonight. Tight."
+
+"You're spoiling the child," said Aunt Martha sourly.
+
+"Auntie," said Tommy, "I bet you're chicken to let your door stay open."
+
+"Well!" huffed Aunt Martha. "The impertinence! I certainly _shall_ keep
+my door open. No mouse is going to keep me from getting good, fresh
+air."
+
+       *       *       *       *       *
+
+Tommy was a very bright little boy. Now, with the door shut in Momma
+and Daddy's room, and Aunt Martha's door open, he wouldn't think about
+the Ugly Thing in the hole--waiting for dark, real dark--to come
+out--and eat.
+
+"All right, Tommy. This once you can sleep with your mother and me. Get
+on to bed and mind you sleep quiet. And don't spread those stuff--your
+family all over the bed either."
+
+"Yes, Daddy. And, Daddy--"
+
+"What?"
+
+"I won't think about it now, the Thing in the hole."
+
+Tommy said his good nights. Tonight he even kissed Aunt Martha as if
+he meant it. And he took his family and he went to bed in Momma and
+Daddy's room.
+
+He did not think about the Ugly Thing. He went right to sleep, lying at
+the edge of the big, big bed. Tommy, and Old Rabbit, and Kokey Koala,
+and even Mr. Bear went right to sleep.
+
+Outside the wind blew hard and harder and the rain drove down and it
+was dark. The television reception was bad. Everyone went to bed early.
+Good night. Lights out.
+
+In Tommy's room it was quite dark with only the faint, watery rays of
+the street light on the corner swimming in through the rain. In the
+closet there was a stirring, a fumbling, a tearing and the hole in the
+blackness grew, was forced, bigger, wider, as the Thing pushed and
+ripped at whatever was barring it from the warm, red, oozing food it
+craved; it must have; it would have.
+
+And, in a sudden gust, the wind blew harder still. Somewhere in town,
+blocks away, a wire fell and blue sparks flashed and crackled in
+the dripping night. In Tommy's house the refrigerator went off, the
+electric clocks stopped. The street light blinked once and was gone and
+in Tommy's closet there was a sudden, mighty surge of effort, a break,
+and something, not a sound, but something, a harsh and bloody sense or
+feel of rending greed flowing outward from the closet in a wave.
+
+Aunt Martha, in her sleep, said, "No. Oh, no!"
+
+Daddy interrupted a snore with a strained grunt. Momma whimpered softly
+and hugged to herself her swollen stomach.
+
+Tommy blinked and was awake. Soothingly, he patted Kokey and Old
+Rabbit. He squeezed Mr. Bear's paw. Then he slipped his hand into the
+opening in Mr. Bear's overalls and took out Daddy's cigarette lighter.
+He knew how to work it. But first he waited.
+
+"Don't think about it," Daddy had told him and he didn't think about
+it, really. But he couldn't help feeling it. The Ugly Thing was out,
+clear out of the hole now, and moving. He could feel that and the awful
+hunger moving with it. Aunt Martha's room was closest and her door was
+open. Momma and Daddy's room was closed. The Ugly Thing moved fast,
+faster, and reached out, thirsting, hungering....
+
+From Aunt Martha's room came the quavering wail and from the Thing
+there flowed a sense of vicious, evil joy.
+
+There it was, but was it enough?
+
+Tommy hugged Mr. Bear once, tightly, and slipped noiselessly from the
+bed. He wasn't thinking about it, he couldn't, he wouldn't think about
+it. But he knew what he had to do. He had the lighter. At the bedroom
+door he worked it. Opened the door a crack; thrust it out. And then, in
+a little rush, back to bed where he lay quietly, and he didn't think
+about it, he and Mr. Bear and Old Rabbit and Kokey Koala.
+
+       *       *       *       *       *
+
+After a little, the sense of feeding hunger was gone and the feel of
+the Ugly Thing was gone, back into the hole in the closet, forced back
+by the flickering yellow light of the flames started by the cigarette
+lighter. Then, when the smell of smoke grew thick in the room and he
+could hear the crackling of the fire burning the house, Tommy shook
+Daddy awake.
+
+It wasn't hard to get out through the bedroom window, except for Momma.
+But she made it all right. And Tommy had a little trouble holding
+tightly to each member of his family as Daddy lifted him out of the
+window, but they made it all right too. Of course Aunt Martha didn't
+make it--how could she? But it was fun watching the firemen in the rain
+from the Krausmeyer's porch next door as the house and the closet with
+the hole in the closet all burned up together.
+
+Aunt Martha?
+
+"Funny thing," Tommy heard one fireman say to another the next day, in
+the sunshine, as they looked over the smouldering ash, "the old bat
+must have been as dry as dust inside. Twenty years in the department
+and I never did see a body so completely consumed--teeth, a little
+bone.... Hey, get on away from here, son! Get along on home with you!"
+
+Daddy and Momma said Aunt Martha had gone away on a trip. Tommy might
+have known pretty well where she had gone, if he had thought about it,
+but he didn't think about it. None of his family did. What for? Aunt
+Martha had had to go away, sure. She went. All right, who missed Aunt
+Martha?
+
+Anyway, there were lights in all of the closets in the new house they
+moved to and lots of room for everyone, even baby sister. And there
+were no holes, not even mouse holes, in any of the closets.
+
+
+
+
+
+End of Project Gutenberg's Don't Think About It, by William W. Stuart
+
+*** END OF THIS PROJECT GUTENBERG EBOOK DON'T THINK ABOUT IT ***
+
+***** This file should be named 60935.txt or 60935.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/6/0/9/3/60935/
+
+Produced by Greg Weeks, Mary Meehan and the Online
+Distributed Proofreading Team at http://www.pgdp.net
+
+Updated editions will replace the previous one--the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for the eBooks, unless you receive
+specific permission. If you do not charge anything for copies of this
+eBook, complying with the rules is very easy. You may use this eBook
+for nearly any purpose such as creation of derivative works, reports,
+performances and research. They may be modified and printed and given
+away--you may do practically ANYTHING in the United States with eBooks
+not protected by U.S. copyright law. Redistribution is subject to the
+trademark license, especially commercial redistribution.
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project
+Gutenberg-tm electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg-tm electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg-tm electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the
+person or entity to whom you paid the fee as set forth in paragraph
+1.E.8.
+
+1.B. "Project Gutenberg" is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg-tm
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation ("the
+Foundation" or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg-tm electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg-tm mission of promoting
+free access to electronic works by freely sharing Project Gutenberg-tm
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg-tm name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg-tm License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg-tm work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country outside the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg-tm License must appear
+prominently whenever any copy of a Project Gutenberg-tm work (any work
+on which the phrase "Project Gutenberg" appears, or with which the
+phrase "Project Gutenberg" is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+  This eBook is for the use of anyone anywhere in the United States and
+  most other parts of the world at no cost and with almost no
+  restrictions whatsoever. You may copy it, give it away or re-use it
+  under the terms of the Project Gutenberg License included with this
+  eBook or online at www.gutenberg.org. If you are not located in the
+  United States, you'll have to check the laws of the country where you
+  are located before using this ebook.
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase "Project
+Gutenberg" associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg-tm
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg-tm License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg-tm work in a format
+other than "Plain Vanilla ASCII" or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original "Plain
+Vanilla ASCII" or other form. Any alternate format must include the
+full Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works
+provided that
+
+* You pay a royalty fee of 20% of the gross profits you derive from
+  the use of Project Gutenberg-tm works calculated using the method
+  you already use to calculate your applicable taxes. The fee is owed
+  to the owner of the Project Gutenberg-tm trademark, but he has
+  agreed to donate royalties under this paragraph to the Project
+  Gutenberg Literary Archive Foundation. Royalty payments must be paid
+  within 60 days following each date on which you prepare (or are
+  legally required to prepare) your periodic tax returns. Royalty
+  payments should be clearly marked as such and sent to the Project
+  Gutenberg Literary Archive Foundation at the address specified in
+  Section 4, "Information about donations to the Project Gutenberg
+  Literary Archive Foundation."
+
+* You provide a full refund of any money paid by a user who notifies
+  you in writing (or by e-mail) within 30 days of receipt that s/he
+  does not agree to the terms of the full Project Gutenberg-tm
+  License. You must require such a user to return or destroy all
+  copies of the works possessed in a physical medium and discontinue
+  all use of and all access to other copies of Project Gutenberg-tm
+  works.
+
+* You provide, in accordance with paragraph 1.F.3, a full refund of
+  any money paid for a work or a replacement copy, if a defect in the
+  electronic work is discovered and reported to you within 90 days of
+  receipt of the work.
+
+* You comply with all other terms of this agreement for free
+  distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg-tm electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from both the Project Gutenberg Literary Archive Foundation and The
+Project Gutenberg Trademark LLC, the owner of the Project Gutenberg-tm
+trademark. Contact the Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg-tm collection. Despite these efforts, Project Gutenberg-tm
+electronic works, and the medium on which they may be stored, may
+contain "Defects," such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg-tm
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg-tm work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg-tm work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at
+www.gutenberg.org
+
+
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation's EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state's laws.
+
+The Foundation's principal office is in Fairbanks, Alaska, with the
+mailing address: PO Box 750175, Fairbanks, AK 99775, but its
+volunteers and employees are scattered throughout numerous
+locations. Its business office is located at 809 North 1500 West, Salt
+Lake City, UT 84116, (801) 596-1887. Email contact links and up to
+date contact information can be found at the Foundation's web site and
+official page at www.gutenberg.org/contact
+
+For additional contact information:
+
+    Dr. Gregory B. Newby
+    Chief Executive and Director
+    gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular
+state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic works.
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg-tm concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg-tm eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our Web site which has the main PG search
+facility: [www.gutenberg.org]
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/projects/sampleBlog/src/app/app-routing.module.ts
+++ b/projects/sampleBlog/src/app/app-routing.module.ts
@@ -3,14 +3,12 @@ import {Routes, RouterModule} from '@angular/router';
 import {AppComponent} from './app.component';
 
 const routes: Routes = [
-  {path: 'test', component: AppComponent},
-  // {path: '', component: AppComponent},
   {
     path: 'about',
     loadChildren: () => import('./about/about.module').then(m => m.AboutModule),
   },
   {
-    path: '',
+    path: 'home',
     loadChildren: () => import('./static/static.module').then(m => m.StaticModule),
   },
   {
@@ -22,6 +20,7 @@ const routes: Routes = [
     loadChildren: () => import('./user/user.module').then(m => m.UserModule),
   },
   {path: 'demo', loadChildren: () => import('./demo/demo.module').then(m => m.DemoModule)},
+  {path: '', redirectTo: '/home', pathMatch: 'full'}
 ];
 
 @NgModule({

--- a/projects/sampleBlog/src/app/app.component.css
+++ b/projects/sampleBlog/src/app/app.component.css
@@ -10,8 +10,8 @@
   color: whitesmoke;
   margin:0;
   padding: 0px 10px;
-  justify-content: center;
-  align-content: center;
+  grid-template-columns: 1fr 40px;
+  place-items: center center;
 }
 
 header h1, footer h3 {

--- a/projects/sampleBlog/src/app/app.component.html
+++ b/projects/sampleBlog/src/app/app.component.html
@@ -1,5 +1,6 @@
 <header>
   <h1>Scully demo blog app!</h1>
+  <a [routerLink]="['/home']">🏠</a>
 </header>
 
 <main>

--- a/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.css
+++ b/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.css
@@ -1,0 +1,17 @@
+:host {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+:host h1:first-child {
+  grid-column: span 3;
+  text-align: center;
+}
+
+article {
+  background-color: royalblue;
+  padding: 5px;
+  border-radius: 5px;
+  color: whitesmoke;
+}

--- a/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.html
+++ b/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.html
@@ -1,0 +1,9 @@
+<h1>Overview of blog posts</h1>
+
+<a *ngFor="let blog of blogs$|async" [routerLink]='[blog.route]'>
+  <article>
+    <h3>{{blog.title || blog.route}}</h3>
+    <h4> {{ blog.published | date:"shortDate" }}</h4>
+    <p>{{blog.description}}</p>
+  </article>
+</a>

--- a/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.spec.ts
+++ b/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BlogListComponent } from './blog-list.component';
+
+describe('BlogListComponent', () => {
+  let component: BlogListComponent;
+  let fixture: ComponentFixture<BlogListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BlogListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BlogListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.ts
+++ b/projects/sampleBlog/src/app/blog/blog-list/blog-list.component.ts
@@ -1,0 +1,18 @@
+import {Component, OnInit} from '@angular/core';
+import {ScullyRoute, ScullyRoutesService} from '@scullyio/ng-lib';
+import {map} from 'rxjs/operators';
+
+@Component({
+  selector: 'app-blog-list',
+  templateUrl: './blog-list.component.html',
+  styleUrls: ['./blog-list.component.css'],
+})
+export class BlogListComponent implements OnInit {
+  blogs$ = this.srs.available$.pipe(
+    map(routeList => routeList.filter((route: ScullyRoute) => route.route.startsWith(`/blog/`)))
+  );
+
+  constructor(private srs: ScullyRoutesService) {}
+
+  ngOnInit() {}
+}

--- a/projects/sampleBlog/src/app/blog/blog-routing.module.ts
+++ b/projects/sampleBlog/src/app/blog/blog-routing.module.ts
@@ -1,10 +1,10 @@
 import {NgModule} from '@angular/core';
-import {Routes, RouterModule, Route} from '@angular/router';
-
+import {RouterModule, Routes} from '@angular/router';
+import {BlogListComponent} from './blog-list/blog-list.component';
 import {BlogComponent} from './blog.component';
 
 const routes: Routes = [
-  {path: '', component: BlogComponent},
+  {path: '', component: BlogListComponent},
   {
     path: ':slug',
     component: BlogComponent,

--- a/projects/sampleBlog/src/app/blog/blog.module.ts
+++ b/projects/sampleBlog/src/app/blog/blog.module.ts
@@ -3,9 +3,10 @@ import {NgModule} from '@angular/core';
 import {ComponentsModule} from '@scullyio/ng-lib';
 import {BlogRoutingModule} from './blog-routing.module';
 import {BlogComponent} from './blog.component';
+import { BlogListComponent } from './blog-list/blog-list.component';
 
 @NgModule({
-  declarations: [BlogComponent],
+  declarations: [BlogComponent, BlogListComponent],
   imports: [CommonModule, BlogRoutingModule, ComponentsModule],
 })
 export class BlogModule {}

--- a/projects/sampleBlog/src/app/demo/demo.component.css
+++ b/projects/sampleBlog/src/app/demo/demo.component.css
@@ -2,7 +2,6 @@
   height: 100%;
   display: grid;
   place-content: center center;
-  font-size: 75vh;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr;
 }
@@ -10,6 +9,8 @@
 span {
   grid-area: 1/1/2/3;
   text-align: center;
+  font-size: 80vw;
+  line-height: 85vh;
 }
 
 a {

--- a/projects/sampleBlog/src/app/static/static-routing.module.ts
+++ b/projects/sampleBlog/src/app/static/static-routing.module.ts
@@ -3,7 +3,10 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { StaticComponent } from './static.component';
 
-const routes: Routes = [{ path: '', component: StaticComponent }];
+const routes: Routes = [
+  { path: ':topLevel', component: StaticComponent },
+  { path: '', component: StaticComponent, pathMatch: 'full' },
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/projects/sampleBlog/src/app/static/static.component.css
+++ b/projects/sampleBlog/src/app/static/static.component.css
@@ -2,3 +2,26 @@ li {
   display:grid;
   grid-template-columns: 200px 200px;
 }
+
+a.btn {
+  display: inline-block;
+  padding: 10px;
+  margin: 10px 3px;
+  width: 200px;
+  height: 40px;
+  border-radius: 4px;
+  background-color: royalblue;
+  color: white;
+  text-align: center;
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+a.btn:hover {
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 6px 6px rgba(0, 0, 0, 0.22);
+}
+
+a.btn:active {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+}

--- a/projects/sampleBlog/src/app/static/static.component.html
+++ b/projects/sampleBlog/src/app/static/static.component.html
@@ -1,13 +1,13 @@
 <h1>Available routes</h1>
 
-<button
-  (click)="toplevelOnly=true;"
+<a class='btn'
+  [routerLink]="['/home','']"
   *ngIf="!toplevelOnly"
->Top level routes only</button>
-<button
-  (click)="toplevelOnly=false;"
+>Top level routes only</a>
+<a class='btn'
+[routerLink]="['/home','all']"
   *ngIf="toplevelOnly"
->All routes</button>
+>All routes</a>
 <ul>
   <li>
     <strong>routelink</strong>

--- a/projects/sampleBlog/src/app/static/static.component.ts
+++ b/projects/sampleBlog/src/app/static/static.component.ts
@@ -1,5 +1,6 @@
-import {Component, OnInit} from '@angular/core';
-import {ScullyRoutesService} from '@scullyio/ng-lib';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ScullyRoutesService } from '@scullyio/ng-lib';
 
 @Component({
   selector: 'app-static',
@@ -7,14 +8,18 @@ import {ScullyRoutesService} from '@scullyio/ng-lib';
   styleUrls: ['./static.component.css'],
 })
 export class StaticComponent implements OnInit {
-  toplevelOnly = false;
+  toplevelOnly = true;
   available$ = this.srs.available$;
   topLevel$ = this.srs.topLevel$;
-  constructor(private srs: ScullyRoutesService) {}
+  constructor(private srs: ScullyRoutesService, private route: ActivatedRoute) {}
 
   get routes() {
     return this.toplevelOnly ? this.topLevel$ : this.available$;
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.route.params.subscribe(params => {
+      this.toplevelOnly = params.topLevel !== 'all';
+    });
+  }
 }

--- a/projects/sampleBlog/src/app/user/user.component.css
+++ b/projects/sampleBlog/src/app/user/user.component.css
@@ -1,18 +1,21 @@
-
 a {
-  display:inline-block;
+  display: inline-block;
   padding: 5px;
   margin: 10px 3px;
-  width:100px;
+  width: 100px;
   border-radius: 4px;
   background-color: royalblue;
-  color:white;
+  color: white;
   text-align: center;
   text-decoration: none;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-  transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
 a:hover {
-  box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+}
+
+a:active {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }

--- a/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.ts
+++ b/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.ts
@@ -74,7 +74,8 @@ export class ScullyContentComponent implements OnInit, OnDestroy {
           try {
             template.innerHTML = html.split(scullyBegin)[1].split(scullyEnd)[0];
           } catch (e) {
-            template.innerHTML = '<h2>Sorry, could not parse static page content</h2>';
+            template.innerHTML = `<h2>Sorry, could not parse static page content</h2>
+            <p>This might happen if you are not using the static generated pages.</p>`;
             console.error('problem during parsing static scully content', e);
           }
         })

--- a/scully.config.js
+++ b/scully.config.js
@@ -1,23 +1,92 @@
-const demoRoutesPlugin = (route, options) => {
-  console.log({route, options});
+const extraRoutesPlugin = (route, options) => {
   const {createPath} = routeSplit(route);
-
-  return Array.from({length:options.numberOfPages},(_v,k)=>k).map(n => ({route: `${createPath(`${n}`)}`, title: `Your mine ${n}`}));
+  if (options.numberOfPages) {
+    return Array.from({length: options.numberOfPages}, (_v, k) => k).map(n => ({
+      route: `${createPath(`${n}`)}`,
+      title: `page number ${n}`,
+    }));
+  }
+  if (options.data) {
+    return options.data.map(item => ({
+      route: createPath(item.data),
+      title: item.title || '',
+    }));
+  }
+  return [];
 };
-demoRoutesPlugin[configValidator] = async config => {
+extraRoutesPlugin[configValidator] = async config => {
   return [];
 };
 
-registerPlugin('router', 'fake', demoRoutesPlugin);
+registerPlugin('router', 'extra', extraRoutesPlugin);
 
 exports.config = {
   /** projectRoot is mandatory! */
-  "projectRoot": "./projects/sampleBlog/src/app",
+  projectRoot: './projects/sampleBlog/src/app',
 
   routes: {
     '/demo/:id': {
-      type: 'fake',
-      numberOfPages: 25
+      type: 'extra',
+      numberOfPages: 10,
+    },
+    '/home/:topLevel': {
+      type: 'extra',
+      data: [
+        {title: 'All routes in application', data: 'all'},
+        {title: 'Toplevel routes in application', data: ''},
+      ],
+    },
+    '/user/:userId': {
+      // Type is mandatory
+      type: 'json',
+      /**
+       * Every parameter in the route must exist here
+       */
+      userId: {
+        url: 'https://jsonplaceholder.typicode.com/users',
+        property: 'id',
+      },
+    },
+    '/ouser/:userId/:friendId': {
+      // Type is mandatory
+      type: 'json',
+      /**
+       * Every parameter in the route must exist here
+       */
+      userId: {
+        url: 'https://jsonplaceholder.typicode.com/users',
+        property: 'id',
+      },
+      friendId: {
+        /** users are their own friend in this sample ;) */
+        url: 'https://jsonplaceholder.typicode.com/users?userId=${userId}',
+        property: 'id',
+      },
+    },
+    '/nouser/:userId/:posts/:comments': {
+      // Type is mandatory
+      type: 'json',
+      /**
+       * Every parameter in the route must exist here
+       */
+      userId: {
+        url: 'https://jsonplaceholder.typicode.com/users',
+        property: 'id',
+      },
+      posts: {
+        url: 'https://jsonplaceholder.typicode.com/posts?userId=${userId}',
+        property: 'id',
+      },
+      comments: {
+        url: 'https://jsonplaceholder.typicode.com/comments?postId=${posts}',
+        property: 'id',
+      },
+    },
+    '/blog/:slug': {
+      type: 'contentFolder',
+      slug: {
+        folder: './blog',
+      },
     },
   },
 };

--- a/scully/renderPlugins/contentRenderPlugin.ts
+++ b/scully/renderPlugins/contentRenderPlugin.ts
@@ -38,7 +38,9 @@ function insertContent(
     return [openingText, startTag, insertText, endTag, ...extras, endText].join('');
   } catch (e) {}
   logWarn(html);
-  return 'Colson could not find the <scully-content> tag in this page.';
+  return `<h1>Scully could not find the &lt.scully-content&gt. tag in this page.</h1>
+  <p>Are you sure you inserted the mandatory "scully-content" in the component that is rendering this page?</p>
+  `;
 }
 
 async function handleFile(extension: string, fileContent: string) {

--- a/scully/routerPlugins/addOptionalRoutesPlugin.ts
+++ b/scully/routerPlugins/addOptionalRoutesPlugin.ts
@@ -1,7 +1,7 @@
 import {plugins} from '../pluginManagement/pluginRepository';
 import {scullyConfig} from '../utils/config';
 import {RoutesTypes, RouteTypes} from '../utils/interfacesandenums';
-import {logError, yellow} from '../utils/log';
+import {logError, yellow, logWarn} from '../utils/log';
 
 export const addOptionalRoutes = async (routeList = [] as string[]): Promise<HandledRoute[]> => {
   const routesToGenerate = await routeList.reduce(
@@ -11,7 +11,7 @@ export const addOptionalRoutes = async (routeList = [] as string[]): Promise<Han
         const r = await routePluginHandler(cur);
         x.push(...r);
       } else if (cur.includes('/:')) {
-        logError(`No configuration for route "${yellow(cur)}" found. Skipping`);
+        logWarn(`No configuration for route "${yellow(cur)}" found. Skipping`);
       } else {
         x.push({route: cur, type: RouteTypes.default});
       }

--- a/scully/utils/defaultAction.ts
+++ b/scully/utils/defaultAction.ts
@@ -21,6 +21,7 @@ export const generateAll = async (config?: Partial<ScullyConfig>) => {
     const appRouteArray = await traverseAppRoutes();
     log('Pull in data to create additional routes.');
     const dataroutes = await addOptionalRoutes(appRouteArray);
+    storeRoutes(dataroutes);
     /** launch the browser, its shared among renderers */
     const browser = await launchedBrowser();
     /** start handling each route, works in chunked parrallel mode  */

--- a/scully/utils/log.ts
+++ b/scully/utils/log.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
-export const {white, red, yellow, green}: {[x: string]: any} = chalk;
+export const {white, red, yellow, green, orange}: {[x: string]: any} = chalk;
 
 export const log = (...a) => console.log(white(...a));
 export const logError = (...a) => console.log(red(...a));
-export const logWarn = (...a) => console.log(yellow(...a));
+export const logWarn = (...a) => console.log(orange(...a));


### PR DESCRIPTION
- Updated the error messages in Scully-content to me more explanatory
- updated the error for the missing <suclly-content> during generation
- updated demo plugin to `extraRoutesPlugin` to make it actually useful
- reworked the home page to use the route for full/top-level routes list
  - this also uses the extraRoutesPlugin
- added a top-level blog route that lists all the blogs
