### PR TITLE
Fix log spelling

### DIFF
--- a/scully/utils/staticServer.ts
+++ b/scully/utils/staticServer.ts
@@ -53,7 +53,7 @@ export async function staticServer(port?: number) {
     );
     angularServerInstance = angularDistServer.listen(scullyConfig.appPort, x => {
       log(
-        `Angular distribuition server started on "${yellow(
+        `Angular distribution server started on "${yellow(
           `http://localhost:${scullyConfig.appPort}/`
         )}" `
       );


### PR DESCRIPTION
There was an incorrect spelling in a log during Scully serve.