### PR TITLE
fix: type slugs as possibly non-empty

### DIFF
--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -6,7 +6,7 @@ import {catchError, shareReplay, switchMap, map, tap} from 'rxjs/operators';
 export interface ScullyRoute {
   route: string;
   title?: string;
-  slugs?: ''[];
+  slugs?: string[];
   [prop: string]: any;
 }
 


### PR DESCRIPTION
The `slugs` property of `ScullyRoute` is currently typed as an array of **empty** strings.

This probably doesn't cause any errors right now, but unless this is intentional, I suggest we use a more appropriate type.