### PR TITLE
fix(ng-lib): correct httpclient import

### DIFF
--- a/projects/scullyio/ng-lib/package.json
+++ b/projects/scullyio/ng-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/ng-lib",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "GIT",
     "url": "https://github.com/scullyio/scully/tree/master/projects/scullyio/ng-lib"

--- a/projects/scullyio/ng-lib/src/lib/components.module.ts
+++ b/projects/scullyio/ng-lib/src/lib/components.module.ts
@@ -1,10 +1,16 @@
-import {HttpClientModule} from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
 import {NgModule} from '@angular/core';
 import {ScullyContentComponent} from './scully-content/scully-content.component';
 
 @NgModule({
   declarations: [ScullyContentComponent],
-  imports: [HttpClientModule],
   exports: [ScullyContentComponent],
 })
-export class ComponentsModule {}
+export class ComponentsModule {
+  static forRoot() {
+    return {
+      NgModule: ComponentsModule,
+      deps: [HttpClient],
+    };
+  }
+}


### PR DESCRIPTION
Instead of loading in the module in ng-lib get the httpclient dep

closes #52