### PR TITLE
feat(sully): prepare scully for running inside Docker container

### DIFF
--- a/scully/renderPlugins/launchedBrowser.ts
+++ b/scully/renderPlugins/launchedBrowser.ts
@@ -1,6 +1,7 @@
 import {Browser, launch, LaunchOptions} from 'puppeteer';
 import {Observable} from 'rxjs';
 import {shareReplay, take} from 'rxjs/operators';
+import {log} from '../utils/log';
 import * as yargs from 'yargs';
 
 const {showBrowser} = yargs
@@ -20,6 +21,12 @@ function obsBrowser(
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   }
 ): Observable<Browser> {
+  const { SCULLY_PUPPETEER_EXECUTABLE_PATH } = process.env;
+  if (SCULLY_PUPPETEER_EXECUTABLE_PATH) {
+    log(`Launching puppeteer with executablePath ${SCULLY_PUPPETEER_EXECUTABLE_PATH}`);
+    options.executablePath = SCULLY_PUPPETEER_EXECUTABLE_PATH;
+    options.args = [...options.args, '--disable-dev-shm-usage'];
+  }
   return new Observable(obs => {
     const promisedBrowser = launch(options);
     promisedBrowser


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?

Currently when running scully in a Docker container it fails with an error message similar to this:

```
Error: Failed to launch chrome! spawn /workspace/node_modules/puppeteer/.local-chromium/linux-706915/chrome-linux/chrome ENOENT
```

## What is the new behavior?

This PR adds the option to instruct Scully to use an existing chromium as executable, allowing it to run inside a Docker container.

It introduces support for the `SCULLY_PUPPETEER_EXECUTABLE_PATH` env var, if this is found it uses it's value as the `executablePath` for Puppeteer.

This allows for running Scully with a prepared Docker image, like [beeman/scully-docker](https://hub.docker.com/r/beeman/scully-docker).

After this patch, scully uses the browser that's pre-installed in the images and runs perfectly fine!

```
$ scully
Launching puppeteer with executablePath /usr/bin/chromium-browser
The option outFolder isn't configured, using default folder "/workspace/dist/static/".
Cleaned up /workspace/dist/static/ folder.
 ☺   new Angular build imported
started servers in background
servers available
Finding all routes in application.
Pull in data to create additional routes.
Finding files in folder "/workspace/blog"
Route list created in files:
      src/assets/scully-routes.json
      /workspace/dist/static/assets/scully-routes.json
Route "" rendered into file: "/workspace/dist/static/index.html"
Route "/blog/12-24-2019-blog" rendered into file: "/workspace/dist/static/blog/12-24-2019-blog/index.html"
Route "/about" rendered into file: "/workspace/dist/static/about/index.html"
Route list created in files:
      src/assets/scully-routes.json
      /workspace/dist/static/assets/scully-routes.json

Generating took 10.23 seconds for 3 pages:
  That is 0.3 pages per second,
  or 3412 milliseconds for each page.

Done in 21.09s.
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Most of the information to build this feature comes from [here](https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md).
