### PR TITLE
fix(scully): make sure scully emits non-zero exit code on errors

### DIFF
--- a/scully/scully.ts
+++ b/scully/scully.ts
@@ -59,7 +59,7 @@ let _options = {};
     const folder = join(scullyConfig.homeFolder, scullyConfig.distFolder);
 
     if (!existDistAngular(scullyConfig.homeFolder)) {
-      process.exit(0);
+      process.exit(15);
     }
 
     await moveDistAngular(folder, scullyConfig.outFolder, {removeStaticDist: true, reset: false});
@@ -105,7 +105,7 @@ let _options = {};
 
       if (!(await waitForServerToBeAvailable().catch(e => false))) {
         logError('Could not connect to server');
-        process.exit(0);
+        process.exit(15);
       }
       console.log('servers available');
       await startScully();
@@ -179,5 +179,5 @@ export async function isBuildThere(config: ScullyConfig) {
     return true;
   }
   logError(`Angular distribution files not found, run "ng build" first`);
-  process.exit(0);
+  process.exit(15);
 }

--- a/scully/utils/config.ts
+++ b/scully/utils/config.ts
@@ -32,7 +32,7 @@ const loadIt = async () => {
     distFolder = angularConfig.projects[defaultProject].architect.build.options.outputPath;
   } catch (e) {
     logError(`Angular config file could not be parsed!`, e);
-    process.exit(0);
+    process.exit(15);
   }
 
   // TODO: update types in interfacesandenums to force correct types in here.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?

Currently scully always emits a `0` as exit code, even when it fails. Emitting a non-zero exit code is essential if you want to use scully in an automated process, as it will halt the process if something fails - currently it just continues.


## What is the new behavior?

Emit exit code 5 ([Fatal exception](https://nodejs.org/api/process.html#process_exit_codes)) when something fails. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
