### PR TITLE
improvement(scully): add routes validation

### DIFF
--- a/scully/routerPlugins/addOptionalRoutesPlugin.ts
+++ b/scully/routerPlugins/addOptionalRoutesPlugin.ts
@@ -4,21 +4,18 @@ import {RoutesTypes, RouteTypes} from '../utils/interfacesandenums';
 import {logError, yellow, logWarn} from '../utils/log';
 
 export const addOptionalRoutes = async (routeList = [] as string[]): Promise<HandledRoute[]> => {
-  const routesToGenerate = await routeList.reduce(
-    async (result: Promise<HandledRoute[]>, cur: string) => {
-      const x = await result;
-      if (scullyConfig.routes[cur]) {
-        const r = await routePluginHandler(cur);
-        x.push(...r);
-      } else if (cur.includes('/:')) {
-        logWarn(`No configuration for route "${yellow(cur)}" found. Skipping`);
-      } else {
-        x.push({route: cur, type: RouteTypes.default});
-      }
-      return x;
-    },
-    Promise.resolve([] as HandledRoute[])
-  );
+  const routesToGenerate = await routeList.reduce(async (result: Promise<HandledRoute[]>, cur: string) => {
+    const x = await result;
+    if (scullyConfig.routes[cur]) {
+      const r = await routePluginHandler(cur);
+      x.push(...r);
+    } else if (cur.includes('/:')) {
+      logWarn(`No configuration for route "${yellow(cur)}" found. Skipping`);
+    } else {
+      x.push({route: cur, type: RouteTypes.default});
+    }
+    return x;
+  }, Promise.resolve([] as HandledRoute[]));
 
   return routesToGenerate;
 };
@@ -44,11 +41,16 @@ async function routePluginHandler(route: string): Promise<HandledRoute[]> {
     return [{route, type: RouteTypes.default}];
   }
   if (plugins.router[conf.type]) {
-    const generatedRoutes = await (plugins.router[conf.type](route, conf) as unknown) as HandledRoute[];
-    generatedRoutes.forEach( handledRoute => {
+    const generatedRoutes = (await (plugins.router[conf.type](route, conf) as unknown)) as HandledRoute[];
+    generatedRoutes.forEach(handledRoute => {
       if (!handledRoute.route.startsWith('/')) {
-        // tslint:disable-next-line:max-line-length
-        logWarn(`The plugin '${conf.type}' needs to return handledRoutes with a route that starts with '/'. The route ${JSON.stringify(handledRoute)} is invalid.`);
+        logWarn(
+          `The plugin '${
+            conf.type
+          }' needs to return handledRoutes with a route that starts with '/'. The route ${JSON.stringify(
+            handledRoute
+          )} is invalid.`
+        );
       }
     });
     return generatedRoutes;

--- a/scully/routerPlugins/addOptionalRoutesPlugin.ts
+++ b/scully/routerPlugins/addOptionalRoutesPlugin.ts
@@ -44,7 +44,14 @@ async function routePluginHandler(route: string): Promise<HandledRoute[]> {
     return [{route, type: RouteTypes.default}];
   }
   if (plugins.router[conf.type]) {
-    return (plugins.router[conf.type](route, conf) as unknown) as HandledRoute[];
+    const generatedRoutes = await (plugins.router[conf.type](route, conf) as unknown) as HandledRoute[];
+    generatedRoutes.forEach( handledRoute => {
+      if (!handledRoute.route.startsWith('/')) {
+        // tslint:disable-next-line:max-line-length
+        logWarn(`The plugin '${conf.type}' needs to return handledRoutes with a route that starts with '/'. The route ${JSON.stringify(handledRoute)} is invalid.`);
+      }
+    });
+    return generatedRoutes;
   }
   return [{route, type: RouteTypes.default}];
 }


### PR DESCRIPTION
When plugins generate routes for scully, we need to validate that the handledRoutes.route start with
/. In this change we show a warning.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Add validation to Handled Routes.
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
