### PR TITLE
feat(transferstateservice): add support fo transfering state from bui…

### DIFF
--- a/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -1,0 +1,129 @@
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { NavigationStart, Router } from '@angular/router';
+import { isScullyGenerated, isScullyRunning } from '../utils/isScully';
+import { Observable, of, Subject } from 'rxjs';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
+
+const SCULLY_SCRIPT_ID = `scully-transfer-state`;
+const SCULLY_STATE_START = `___SCULLY_STATE_START___`;
+const SCULLY_STATE_END = `___SCULLY_STATE_END___`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TransferStateService {
+  private script: HTMLScriptElement;
+  private state: { [key: string]: any } = {};
+  private fetching: Subject<any>;
+
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private router: Router,
+    private http: HttpClient,
+  ) {
+    this.setupEnvForTransferState();
+    this.setupNavStartDataFetching();
+  }
+
+  private setupEnvForTransferState(): void {
+    if (isScullyRunning()) {
+      // In Scully puppeteer
+      this.script = this.document.createElement('script');
+      this.script.setAttribute('id', SCULLY_SCRIPT_ID);
+      this.script.setAttribute('type', `text/${SCULLY_SCRIPT_ID}`);
+      this.document.head.appendChild(this.script);
+    } else if (isScullyGenerated()) {
+      // On the client AFTER scully rendered it
+      this.script = this.document.getElementById(SCULLY_SCRIPT_ID) as HTMLScriptElement;
+      try {
+        this.state = JSON.parse(unescapeHtml(this.script.textContent));
+      } catch (e) {
+        this.state = {};
+      }
+    }
+  }
+
+  getState<T>(name: string): Observable<T> {
+    if (this.fetching) {
+      return this.fetching.pipe(map(() => this.state[name]));
+    } else {
+      return of(this.state[name]);
+    }
+  }
+
+  setState<T>(name: string, val: T): void {
+    this.state[name] = val;
+    if (isScullyRunning()) {
+      this.script.textContent = `${SCULLY_STATE_START}${escapeHtml(
+        JSON.stringify(this.state),
+      )}${SCULLY_STATE_END}`;
+    }
+  }
+
+  setupNavStartDataFetching() {
+    /**
+     * Each time the route changes, get the Scully state from the server-rendered page
+     */
+    if (!isScullyGenerated()) return;
+
+    this.router.events
+      .pipe(
+        filter(e => e instanceof NavigationStart),
+        tap(() => (this.fetching = new Subject<any>())),
+        switchMap((e: NavigationStart) => {
+          // Get the next route's page from the server
+          return this.http.get(e.url, { responseType: 'text' });
+        }),
+        map((html: string) => {
+          // Parse the scully state out of the next page
+          const startIndex = html.indexOf(SCULLY_STATE_START);
+          if (startIndex !== -1) {
+            const afterStart = html.split(SCULLY_STATE_START)[1] || '';
+            const middle = afterStart.split(SCULLY_STATE_END)[0] || '';
+            return middle;
+          } else {
+            return null;
+          }
+        }),
+        filter(val => val !== null),
+        tap(val => {
+          // Add parsed-out scully-state to the current scully-state
+          this.setFetchedRouteState(val);
+          this.fetching = null;
+        }),
+      )
+      .subscribe();
+  }
+
+  private setFetchedRouteState(unprocessedTextContext) {
+    // Exit if nothing to set
+    if (!unprocessedTextContext || !unprocessedTextContext.length) return;
+
+    // Parse to JSON the next route's state content
+    const newState = JSON.parse(unescapeHtml(unprocessedTextContext));
+    this.state = { ...this.state, ...newState };
+    this.fetching.next();
+  }
+}
+export function unescapeHtml(text: string): string {
+  const unescapedText: { [k: string]: string } = {
+    '&a;': '&',
+    '&q;': '"',
+    '&s;': "'",
+    '&l;': '<',
+    '&g;': '>',
+  };
+  return text.replace(/&[^;]+;/g, s => unescapedText[s]);
+}
+export function escapeHtml(text: string): string {
+  const escapedText: { [k: string]: string } = {
+    '&': '&a;',
+    '"': '&q;',
+    "'": '&s;',
+    '<': '&l;',
+    '>': '&g;',
+  };
+  return text.replace(/[&"'<>]/g, s => escapedText[s]);
+}

--- a/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -74,11 +74,12 @@ export class TransferStateService {
         tap(() => (this.fetching = new Subject<any>())),
         switchMap((e: NavigationStart) => {
           // Get the next route's page from the server
-          return this.http.get(e.url, {responseType: 'text'});
-        }),
-        catchError(err => {
-          console.warn('Failed transfering state from route', err);
-          return of('');
+          return this.http.get(e.url, {responseType: 'text'}).pipe(
+            catchError(err => {
+              console.warn('Failed transfering state from route', err);
+              return of('');
+            })
+          );
         }),
         map((html: string) => {
           // Parse the scully state out of the next page

--- a/projects/scullyio/ng-lib/src/public-api.ts
+++ b/projects/scullyio/ng-lib/src/public-api.ts
@@ -4,7 +4,7 @@
 
 export * from './lib/components.module';
 export * from './lib/idleMonitor/idle-monitor.service';
+export * from './lib/transfer-state/transfer-state.service';
 export * from './lib/route-service/scully-routes.service';
 export * from './lib/scully-content/scully-content.component';
 export * from './lib/utils/isScully';
-

--- a/schematics/scully/src/ng-add/index.ts
+++ b/schematics/scully/src/ng-add/index.ts
@@ -29,9 +29,7 @@ export default function(options: Schema): Rule {
     if (polyfills.includes('SCULLY IMPORTS')) {
       context.logger.info('⚠️️  Skipping polyfills.ts');
     } else {
-      polyfills =
-        polyfills +
-        `\n/***************************************************************************************************
+      polyfills = `${polyfills}\n/***************************************************************************************************
   \n* SCULLY IMPORTS
   \n*/
   \n// tslint:disable-next-line: align \nimport 'zone.js/dist/task-tracking';`;
@@ -44,10 +42,10 @@ export default function(options: Schema): Rule {
       if (appComponent.includes('IdleMonitorService')) {
         context.logger.info('⚠️️  Skipping ./src/app/app.component.ts');
       } else {
-        const idleImport = "import {IdleMonitorService} from '@scullyio/ng-lib';";
+        const idleImport = "import {IdleMonitorService, TransferStateService} from '@scullyio/ng-lib';";
         // add
         const idImport = `${idleImport} \n ${appComponent}`;
-        const idle = 'private idle: IdleMonitorService';
+        const idle = 'private idle: IdleMonitorService, private transferState: TransferStateService';
         let output = '';
         // check if exist
         if (idImport.search(/constructor/).toString() === '-1') {
@@ -79,11 +77,9 @@ export default function(options: Schema): Rule {
         return '';
       }
 
-
     } catch (e) {
       console.log('error in idle service');
     }
-
 
     const nextRules: Rule[] = [];
     // tslint:disable-next-line:triple-equals

--- a/scully/package-lock.json
+++ b/scully/package-lock.json
@@ -160,7 +160,8 @@
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "optional": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -174,7 +175,8 @@
     "acorn": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+      "optional": true
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -302,7 +304,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -497,6 +500,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -580,7 +584,8 @@
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "optional": true
     },
     "cssstyle": {
       "version": "1.4.0",
@@ -649,7 +654,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -671,6 +677,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "optional": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
@@ -832,7 +839,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -1187,7 +1195,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
     },
     "jsdom": {
       "version": "15.1.1",
@@ -1321,7 +1330,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "optional": true
     },
     "make-error": {
       "version": "1.3.5",
@@ -1560,7 +1570,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "optional": true
     },
     "prettier": {
       "version": "1.19.1",
@@ -1595,12 +1606,14 @@
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "optional": true
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "optional": true
     },
     "puppeteer": {
       "version": "2.0.0",
@@ -2046,6 +2059,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "optional": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -2080,12 +2094,14 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -2184,12 +2200,14 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "optional": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
@@ -2197,12 +2215,14 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "optional": true
     },
     "whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
       "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "optional": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -2247,7 +2267,8 @@
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "optional": true
     },
     "xmlchars": {
       "version": "2.2.0",


### PR DESCRIPTION
…ldtime to runtime

TransferStateService allows you to set state and scully build time that can be used at run time in
the browser. It also supports loading the state on subsequent route changes AFTER the initial page
load.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
