### PR TITLE
fix(scully): fix the pointer in the package.json to point at the bin …

### DIFF
--- a/scully/package.json
+++ b/scully/package.json
@@ -9,7 +9,7 @@
   "bin": {
     "scully": "./bin/scully.js"
   },
-  "main": "index.js",
+  "main": "bin/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "tsc -p ./tsconfig.scully.json -w",


### PR DESCRIPTION
…folder

Once we have deployed to npm, we want people to just point to `@scullyio/scully` from the code. This
change makes that possibly. Without it, you have to point to `@scullyio/scully/bin`, which isn't
intuitive.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
