### PR TITLE
refactor(ng-lib): manage HttpClient dependency

### DIFF
--- a/projects/scullyio/ng-lib/src/lib/components.module.spec.ts
+++ b/projects/scullyio/ng-lib/src/lib/components.module.spec.ts
@@ -1,0 +1,41 @@
+import {
+  HTTP_INTERCEPTORS,
+  HttpBackend,
+  HttpClient,
+  HttpXsrfTokenExtractor,
+  XhrFactory,
+} from '@angular/common/http';
+import { AbstractType, InjectionToken, Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ComponentsModule } from './components.module';
+
+type TestBedInjectToken<T> = Type<T> | InjectionToken<T> | AbstractType<T>;
+
+describe(ComponentsModule.name, () => {
+  const httpClientAndDependenciesWithNames: ReadonlyArray<[TestBedInjectToken<any>, string]> = [
+    [HttpClient, HttpClient.name],
+    [HttpBackend, HttpBackend.name],
+    [HTTP_INTERCEPTORS, 'HTTP_INTERCEPTORS'],
+    [XhrFactory, XhrFactory.name],
+    [HttpXsrfTokenExtractor, HttpXsrfTokenExtractor.name],
+  ];
+
+  httpClientAndDependenciesWithNames.forEach(([token, tokenName]) => {
+    it(`forRoot provides ${tokenName} to support HttpClient`, () => {
+      TestBed.configureTestingModule({
+        imports: [ComponentsModule.forRoot()],
+      });
+
+      expect(() => TestBed.inject(token)).not.toThrow();
+    });
+  });
+
+  it('does not provide HttpClient when imported as a regular Angular module', () => {
+    TestBed.configureTestingModule({
+      imports: [ComponentsModule],
+    });
+
+    expect(() => TestBed.inject(HttpClient)).toThrowError(/NullInjectorError/);
+  });
+});

--- a/projects/scullyio/ng-lib/src/lib/components.module.spec.ts
+++ b/projects/scullyio/ng-lib/src/lib/components.module.spec.ts
@@ -2,6 +2,7 @@ import {
   HTTP_INTERCEPTORS,
   HttpBackend,
   HttpClient,
+  HttpClientModule,
   HttpXsrfTokenExtractor,
   XhrFactory,
 } from '@angular/common/http';
@@ -29,6 +30,14 @@ describe(ComponentsModule.name, () => {
 
       expect(() => TestBed.inject(token)).not.toThrow();
     });
+  });
+
+  it('forRoot works side-by-side with HttpClientModule', () => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule, ComponentsModule.forRoot()],
+    });
+
+    expect(() => TestBed.inject(HttpClient)).not.toThrow();
   });
 
   it('does not provide HttpClient when imported as a regular Angular module', () => {

--- a/projects/scullyio/ng-lib/src/lib/components.module.ts
+++ b/projects/scullyio/ng-lib/src/lib/components.module.ts
@@ -1,16 +1,18 @@
-import {HttpClient} from '@angular/common/http';
-import {ModuleWithProviders, NgModule} from '@angular/core';
-import {ScullyContentComponent} from './scully-content/scully-content.component';
+import { HttpClientModule } from '@angular/common/http';
+import { ModuleWithProviders, NgModule } from '@angular/core';
+
+import {
+  ScullyContentComponent,
+} from './scully-content/scully-content.component';
 
 @NgModule({
   declarations: [ScullyContentComponent],
   exports: [ScullyContentComponent],
 })
 export class ComponentsModule {
-  static forRoot(): ModuleWithProviders<ComponentsModule> {
+  static forRoot(): ModuleWithProviders<HttpClientModule> {
     return {
-      ngModule: ComponentsModule,
-      providers: [HttpClient],
+      ngModule: HttpClientModule,
     };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
`ComponentsModule.forRoot` only provides `HttpClient`, but not its dependencies.

Pull Requests: #69 #75
Issue Number: #52

## What is the new behavior?
Instead of providing only `HttpClient`, but not its dependencies, we now re-export `HttpClientModule` in the static `forRoot` method of `ComponentsModule`.

I have also added a test suite for the `ComponentsModule` which exercises injecting `HttpClient` and its dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Note that the `init` schematic currently adds `HttpClientModule` to the consumers `AppModule` `imports`.

Sorry for bringing this up again, but the current implementation only provides `HttpClient`. I did some digging and discovered that `HttpClientModule` actually provides quite a few dependencies used by `HttpClient` at runtime.

How do we want to handle this?

In the new approach of this PR, I simply re-export `HttpClientModule` in `ComponentsModule.forRoot`.

Usually, we would just expect the consuming application to inject `HttpClientModule`. The classes depending on `HttpClient` (`ScullyRoutesService` and `ScullyContentComponent`) would crash at runtime, if `HttpClient` and its dependencies were not provided by the consuming application.

Is this a better option? Then we can remove the static `forRoot` method instead. If so, we could probably detect the error early by attempting to inject `HttpClient` in `ComponentsModule`'s constructor as an optional dependency and throw an error with a helpful message if it could not be resolved.