### PR TITLE
fix(scully-content.component): don't try to re-render content when navigating one level "up"

### DIFF
--- a/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.ts
+++ b/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.ts
@@ -106,7 +106,8 @@ export class ScullyContentComponent implements OnInit, OnDestroy {
 
         ev.preventDefault();
         this.router.navigate(splitRoute).catch(e => console.error('routing error', e));
-        if (curSplit.every((part, i) => splitRoute[i] === part)) {
+        /** check for the same route with different "data", and NOT a level higher (length) */
+        if (curSplit.every((part, i) => splitRoute[i] === part) && splitRoute.length > curSplit.length) {
           setTimeout(() => {
             const p = this.elm.parentElement;
             let cur = findComments(p, 'scullyContent-begin')[0] as HTMLElement;


### PR DESCRIPTION

closes #121

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
fixes a bug that ahppened when you navigated from a blog page to a level above. It tried to render the scully content for the new page, where it should not do that,

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
throws error:
Issue Number: 121


## What is the new behavior?
doesn't throw the error anymore

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
