### PR TITLE
fix(scully-routes.service): fix missing return type

### DIFF
--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -16,7 +16,7 @@ export interface ScullyRoute {
 })
 export class ScullyRoutesService {
   private refresh = new ReplaySubject<void>(1);
-  available$ = this.refresh.pipe(
+  available$: Observable<ScullyRoute[]> = this.refresh.pipe(
     switchMap(() => this.http.get<ScullyRoute[]>('/assets/scully-routes.json')),
     catchError(() => {
       console.warn('Scully routes file not found, are you running the in static version of your site?');
@@ -25,7 +25,7 @@ export class ScullyRoutesService {
     shareReplay({refCount: false, bufferSize: 1})
   );
 
-  topLevel$ = this.available$.pipe(
+  topLevel$: Observable<ScullyRoute[]> = this.available$.pipe(
     map(routes => routes.filter((r: ScullyRoute) => !r.route.slice(1).includes('/'))),
     shareReplay({refCount: false, bufferSize: 1})
   );
@@ -54,7 +54,7 @@ export class ScullyRoutesService {
     );
   }
 
-  reload() {
+  reload(): void {
     this.refresh.next();
   }
 }

--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -1,7 +1,8 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {of, ReplaySubject} from 'rxjs';
+import {of, ReplaySubject, Observable} from 'rxjs';
 import {catchError, shareReplay, switchMap, map, tap} from 'rxjs/operators';
+import {HandledRoute} from 'dist/scully';
 
 export interface ScullyRoute {
   route: string;
@@ -18,9 +19,7 @@ export class ScullyRoutesService {
   available$ = this.refresh.pipe(
     switchMap(() => this.http.get<ScullyRoute[]>('/assets/scully-routes.json')),
     catchError(() => {
-      console.warn(
-        'Scully routes file not found, are you running the in static version of your site?'
-      );
+      console.warn('Scully routes file not found, are you running the in static version of your site?');
       return of([] as ScullyRoute[]);
     }),
     shareReplay({refCount: false, bufferSize: 1})
@@ -36,10 +35,10 @@ export class ScullyRoutesService {
     this.reload();
   }
 
-  getCurrent() {
+  getCurrent(): Observable<ScullyRoute> {
     if (!location) {
       /** probably not in a browser, no current location available */
-      return of([]);
+      return of();
     }
     const curLocation = location.pathname;
     return this.available$.pipe(


### PR DESCRIPTION
Put in the correct type for the return of the getCurrent function. In some cases TS inferrrence is
off otherwise

closes #171

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
typing of the getCurrent method is off
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #171 


## What is the new behavior?
It returns the correct type.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
