### PR TITLE
fix(remove httpclientmodule): refactor to drop depedency on httpClien…

### DIFF
--- a/extraPlugin/newSample.js
+++ b/extraPlugin/newSample.js
@@ -1,0 +1,47 @@
+const {routeSplit, registerPlugin, httpGet} = require('../dist/scully');
+
+const newsSamplePlugin = async (route, config) => {
+  const {createPath} = routeSplit(route);
+  const list = await httpGet('http://localhost:4200/assets/news.json');
+  const handledRoutes = [];
+  for (item of list) {
+    const blogData = await httpget(`http://localhost:4200/assets/news/${list.id}.json`);
+    handledRoutes.push({
+      route: createPath(item.id, blogdata.slug),
+      title: blogData.title,
+      description: blogData.short,
+    });
+  }
+};
+
+registerPlugin('router', 'myBlog', newsSamplePlugin);
+
+const config = {
+  '/news/:id/:slug': {
+    type: 'myBlog',
+    postRenderers: postRenderers,
+  },
+};
+
+/**
+ *
+    '/news/:id/:slug': {
+      type: 'json',
+      postRenderers: postRenderers,
+      id: {
+        url: 'http://localhost:4200/assets/news.json',
+        property: 'id',
+      },
+      slug: {
+        url: 'http://localhost:4200/assets/news/${id}.json',
+        property: 'slug',
+      },
+},
+
+{
+  "id": 5,
+  "slug": "newsitem-5",
+  "title": "Newsitem #5",
+  "short": "Lorem ipsum dolor .."
+}
+ */

--- a/projects/scullyio/ng-lib/package.json
+++ b/projects/scullyio/ng-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/ng-lib",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "GIT",
     "url": "https://github.com/scullyio/scully/tree/master/projects/scullyio/ng-lib"

--- a/projects/scullyio/ng-lib/src/lib/components.module.ts
+++ b/projects/scullyio/ng-lib/src/lib/components.module.ts
@@ -1,16 +1,8 @@
-import {HttpClient} from '@angular/common/http';
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {ScullyContentComponent} from './scully-content/scully-content.component';
 
 @NgModule({
   declarations: [ScullyContentComponent],
   exports: [ScullyContentComponent],
 })
-export class ComponentsModule {
-  static forRoot(): ModuleWithProviders<ComponentsModule> {
-    return {
-      ngModule: ComponentsModule,
-      providers: [HttpClient],
-    };
-  }
-}
+export class ComponentsModule {}

--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.spec.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.spec.ts
@@ -1,23 +1,13 @@
-import {
-  HttpClientTestingModule,
-  HttpTestingController,
-} from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
-import { ScullyRoutesService } from './scully-routes.service';
+import {ScullyRoutesService} from './scully-routes.service';
 
 describe('ScullyRoutesService', () => {
   let service: ScullyRoutesService;
-  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-      ],
-    });
+    TestBed.configureTestingModule({});
     service = TestBed.inject(ScullyRoutesService);
-    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {

--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -1,8 +1,7 @@
-import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {of, ReplaySubject, Observable} from 'rxjs';
-import {catchError, shareReplay, switchMap, map, tap} from 'rxjs/operators';
-import {HandledRoute} from 'dist/scully';
+import {Observable, of, ReplaySubject} from 'rxjs';
+import {catchError, map, shareReplay, switchMap} from 'rxjs/operators';
+import {fetchHttp} from '../utils/fetchHttp';
 
 export interface ScullyRoute {
   route: string;
@@ -17,7 +16,7 @@ export interface ScullyRoute {
 export class ScullyRoutesService {
   private refresh = new ReplaySubject<void>(1);
   available$: Observable<ScullyRoute[]> = this.refresh.pipe(
-    switchMap(() => this.http.get<ScullyRoute[]>('/assets/scully-routes.json')),
+    switchMap(() => fetchHttp<ScullyRoute[]>('/assets/scully-routes.json')),
     catchError(() => {
       console.warn('Scully routes file not found, are you running the in static version of your site?');
       return of([] as ScullyRoute[]);
@@ -30,7 +29,7 @@ export class ScullyRoutesService {
     shareReplay({refCount: false, bufferSize: 1})
   );
 
-  constructor(private http: HttpClient) {
+  constructor() {
     /** kick off first cycle */
     this.reload();
   }

--- a/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.spec.ts
+++ b/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.spec.ts
@@ -1,30 +1,19 @@
-import {
-  HttpClientTestingModule,
-  HttpTestingController,
-} from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-
-import { ScullyContentComponent } from './scully-content.component';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ScullyContentComponent} from './scully-content.component';
 
 describe('ScullyContentComponent', () => {
   let component: ScullyContentComponent;
   let fixture: ComponentFixture<ScullyContentComponent>;
-  let httpTestingController: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ScullyContentComponent],
-      imports: [
-        HttpClientTestingModule,
-        RouterTestingModule.withRoutes([]),
-      ],
-    })
-      .compileComponents();
+      imports: [RouterTestingModule.withRoutes([])],
+    }).compileComponents();
   }));
 
   beforeEach(() => {
-    httpTestingController = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(ScullyContentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.ts
+++ b/projects/scullyio/ng-lib/src/lib/scully-content/scully-content.component.ts
@@ -1,4 +1,3 @@
-import {HttpClient} from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -13,6 +12,7 @@ import {Observable, Subscription} from 'rxjs';
 import {take} from 'rxjs/operators';
 import {IdleMonitorService} from '../idleMonitor/idle-monitor.service';
 import {ScullyRoutesService} from '../route-service/scully-routes.service';
+import {fetchHttp} from '../utils/fetchHttp';
 
 /** this is needed, because otherwise the CLI borks while building */
 const scullyBegin = '<!--scullyContent-begin-->';
@@ -45,7 +45,6 @@ export class ScullyContentComponent implements OnInit, OnDestroy {
   constructor(
     private elmRef: ElementRef,
     private srs: ScullyRoutesService,
-    private http: HttpClient,
     private router: Router,
     private idle: IdleMonitorService
   ) {}
@@ -67,16 +66,13 @@ export class ScullyContentComponent implements OnInit, OnDestroy {
       template.innerHTML = window['scullyContent'];
     } else {
       const curPage = location.href;
-      await this.http
-        .get(curPage, {responseType: 'text'})
-        .toPromise()
+      await fetchHttp(curPage, 'text')
         .then((html: string) => {
           try {
             template.innerHTML = html.split(scullyBegin)[1].split(scullyEnd)[0];
           } catch (e) {
             template.innerHTML = `<h2>Sorry, could not parse static page content</h2>
             <p>This might happen if you are not using the static generated pages.</p>`;
-            console.error('problem during parsing static scully content', e);
           }
         })
         .catch(e => {

--- a/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -93,10 +93,10 @@ export class TransferStateService {
           }
         }),
         filter(val => val !== null),
-        tap(newState => {
-          // Add parsed-out scully-state to the current scully-state
-          this.setFetchedRouteState(newState);
-        })
+        /** only when data comes out here, navigation is done for transferState */
+        tap(() => (this.isNavigating = false)),
+        // Add parsed-out scully-state to the current scully-state
+        tap(newState => this.setFetchedRouteState(newState))
       )
       .subscribe();
   }

--- a/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -67,12 +67,10 @@ export class TransferStateService {
         filter(e => e instanceof NavigationStart),
         switchMap((e: NavigationStart) => {
           // Get the next route's page from the server
-          return from(fetchHttp(e.url, 'text')).pipe(
-            catchError(err => {
-              console.warn('Failed transfering state from route', err);
-              return of('');
-            })
-          );
+          return fetchHttp(e.url + '/index.html', 'text').catch(err => {
+            console.warn('Failed transfering state from route', err);
+            return '';
+          });
         }),
         map((html: string) => {
           try {

--- a/projects/scullyio/ng-lib/src/lib/utils/fetchHttp.ts
+++ b/projects/scullyio/ng-lib/src/lib/utils/fetchHttp.ts
@@ -1,0 +1,10 @@
+export function fetchHttp<T>(url: string, responseType: XMLHttpRequestResponseType = 'json'): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.responseType = responseType;
+    xhr.addEventListener('load', ev => resolve(xhr.response));
+    xhr.addEventListener('error', (...err) => reject(err));
+    xhr.open('get', url, true);
+    xhr.send();
+  });
+}

--- a/scully.config.js
+++ b/scully.config.js
@@ -32,7 +32,7 @@ exports.config = {
         property: 'id',
       },
     },
-    '/ouser/:userId/:friendId': {
+    '/user/:userId/:friendCode': {
       // Type is mandatory
       type: 'json',
       /**
@@ -42,7 +42,7 @@ exports.config = {
         url: 'https://jsonplaceholder.typicode.com/users',
         property: 'id',
       },
-      friendId: {
+      friendCode: {
         /** users are their own friend in this sample ;) */
         url: 'https://jsonplaceholder.typicode.com/users?userId=${userId}',
         property: 'id',

--- a/scully/renderPlugins/routeContentRenderer.ts
+++ b/scully/renderPlugins/routeContentRenderer.ts
@@ -14,13 +14,17 @@ export const routeContentRenderer = async (route: HandledRoute) => {
     const handler = plugins.render[plugin];
     if (handler) {
       try {
+        /** return result of plugin */
         return await handler(html, route);
       } catch {
         logError(
-          `Error during content generation with plugin "${yellow(plugin)}" for ${yellow(route.templateFile)}`
+          `Error during content generation with plugin "${yellow(plugin)}" for ${yellow(
+            route.templateFile
+          )}. This hander is skipped.`
         );
       }
     }
+    /** return unhandled result */
     return html;
   }, puppeteerRender(route));
 };


### PR DESCRIPTION
…tModule

This refactor takes care of the httpClientModule, by replacing it with a fetchHttp from our own
making.

@aaronfrost I tested it true, but I a bit wary about the tranferstate in this one. Can you double-check before we merge this one?