### PR TITLE
feat(Scully config): adds an option to set the puppeteer launch options

### DIFF
--- a/docs/scully-configuration.md
+++ b/docs/scully-configuration.md
@@ -8,7 +8,7 @@ also if you want to enhance you project made with scully, visit the [Utils](util
 or teach to the community how to combine scully with others tools.
 
 - [Scully Configuration](#scully-configuration)
-  - [ScullyConfig Interface](#scullyconfig-interface)
+  - [`ScullyConfig` Interface](#scullyconfig-interface)
   - [scullyConfig properties explained](#scullyconfig-properties-explained)
     - [projectRoot](#projectroot)
     - [homeFolder](#homefolder)
@@ -123,5 +123,6 @@ The port by default is: `1668`
 When in a restricted environment there is a change the default options for puppeteer won't work. In such a case
 this option can override the puppeteerLaunchOptions with settings that match this environment.
 Word of warning, some settings might interfer with the way Scully is working, creating errornous results.
+Follow [this link](https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-puppeteerlaunchoptions) for more information
 
 [Full Documentation ➡️](scully.md)

--- a/docs/scully-configuration.md
+++ b/docs/scully-configuration.md
@@ -7,15 +7,20 @@ If you are starting to use scully we highly recommend read the [Getting Started]
 also if you want to enhance you project made with scully, visit the [Utils](utils.md) section and see
 or teach to the community how to combine scully with others tools.
 
-- [`ScullyConfig` Interface](#scullyconfig-interface)
-- [projectRoot](#projectRoot)
-- [homeFolder](#homeFolder)
-- [outDir](#outDir)
-- [distFolder](#distFolder)
-- [routes](#routes)
-- [extraRoutes](#extraRoutes)
-- [appPort](#appPort)
-- [staticport](#staticport)
+- [Scully Configuration](#scully-configuration)
+  - [ScullyConfig Interface](#scullyconfig-interface)
+  - [scullyConfig properties explained](#scullyconfig-properties-explained)
+    - [projectRoot](#projectroot)
+    - [homeFolder](#homefolder)
+    - [outDir](#outdir)
+    - [distFolder](#distfolder)
+    - [routes](#routes)
+      - [handled Routes](#handled-routes)
+      - [unhandled Routes](#unhandled-routes)
+    - [extraRoutes](#extraroutes)
+    - [appPort](#appport)
+    - [staticport](#staticport)
+    - [puppeteerLaunchOptions](#puppeteerlaunchoptions)
 
 ## `ScullyConfig` Interface
 
@@ -29,10 +34,13 @@ export interface ScullyConfig {
   extraRoutes?: string[];
   appPort: number;
   staticport: number;
+  puppeteerLaunchOptions?: LaunchOptions;
 }
 ```
 
 `ScullyConfig` interface provide the parameters to configure how scully works in your project.
+
+## scullyConfig properties explained
 
 ### projectRoot
 
@@ -87,7 +95,7 @@ I you want to know more about plugins go to [Plugins](plugins.md) section.
 
 ### extraRoutes
 
-The `extraRoutes` property allow to the developer add an array of handled routes to discover by Scully.
+The `extraRoutes` property allow to the developer add an array of unhandled routes to discover by Scully.
 These can be routes that exist in AngularJS, or in React, or in whatever Framework's router.
 
 It can be handle `:string`, `Promise<string>` or `Promise<Array<string>>`
@@ -109,5 +117,11 @@ Similarly as _appPort_, the property `staticport` allow the developer set up a p
 which will serve static files compiled by Scully.
 
 The port by default is: `1668`
+
+### puppeteerLaunchOptions
+
+When in a restricted environment there is a change the default options for puppeteer won't work. In such a case
+this option can override the puppeteerLaunchOptions with settings that match this environment.
+Word of warning, some settings might interfer with the way Scully is working, creating errornous results.
 
 [Full Documentation ➡️](scully.md)

--- a/scully/renderPlugins/launchedBrowser.ts
+++ b/scully/renderPlugins/launchedBrowser.ts
@@ -3,6 +3,7 @@ import {Observable} from 'rxjs';
 import {shareReplay, take} from 'rxjs/operators';
 import {log} from '../utils/log';
 import * as yargs from 'yargs';
+import {scullyConfig} from '../utils/config';
 
 const {showBrowser} = yargs
   .boolean('sb')
@@ -14,14 +15,13 @@ const launched = obsBrowser().pipe(shareReplay({refCount: false, bufferSize: 1})
 export const launchedBrowser: () => Promise<Browser> = () => launched.pipe(take(1)).toPromise();
 let browser: Browser;
 
-function obsBrowser(
-  options: LaunchOptions = {
-    headless: !showBrowser,
-    // dumpio: true,
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+function obsBrowser(options: LaunchOptions = scullyConfig.puppeteerLaunchOptions || {}): Observable<Browser> {
+  if (showBrowser) {
+    options.headless = false;
   }
-): Observable<Browser> {
-  const { SCULLY_PUPPETEER_EXECUTABLE_PATH } = process.env;
+  // option.args= ['--no-sandbox', '--disable-setuid-sandbox'],
+
+  const {SCULLY_PUPPETEER_EXECUTABLE_PATH} = process.env;
   if (SCULLY_PUPPETEER_EXECUTABLE_PATH) {
     log(`Launching puppeteer with executablePath ${SCULLY_PUPPETEER_EXECUTABLE_PATH}`);
     options.executablePath = SCULLY_PUPPETEER_EXECUTABLE_PATH;

--- a/scully/utils/interfacesandenums.ts
+++ b/scully/utils/interfacesandenums.ts
@@ -1,3 +1,5 @@
+import {LaunchOptions} from 'puppeteer';
+
 export enum RouteTypes {
   json = 'json',
   contentFolder = 'contentFolder',
@@ -14,6 +16,7 @@ export interface ScullyConfig {
   extraRoutes?: string[];
   appPort: number;
   staticport: number;
+  puppeteerLaunchOptions?: LaunchOptions;
 }
 
 interface RouteConfig {


### PR DESCRIPTION
closes #181
add an option to the config to set puppeteers launch options. might be needed in restricted environments

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
None
Issue Number: #181 


## What is the new behavior?
have an option to address #181 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
