### PR TITLE
feat(pluginrpository.ts): refactor registerplugin to take validator

### DIFF
--- a/scully/pluginManagement/pluginRepository.ts
+++ b/scully/pluginManagement/pluginRepository.ts
@@ -46,12 +46,10 @@ export const registerPlugin = (
   if (replaceExistingPlugin === false && plugins[type][name]) {
     throw new Error(`Plugin ${name} already exists`);
   }
-  if (type === 'router' && configValidator === undefined) {
+  if (type === 'router' && validator === undefined) {
     logError(`
 ---------------
-   Route plugin "${yellow(name)}" should have an config validator attached to '${
-      plugin.name
-    }[configValidator]'
+   Route plugin "${yellow(name)}" should have an config validator attached to '${plugin.name}'
 ---------------
 `);
     plugin[configValidator] = async () => [];

--- a/scully/pluginManagement/pluginRepository.ts
+++ b/scully/pluginManagement/pluginRepository.ts
@@ -46,7 +46,7 @@ export const registerPlugin = (
   if (replaceExistingPlugin === false && plugins[type][name]) {
     throw new Error(`Plugin ${name} already exists`);
   }
-  if (type === 'router' && validator === undefined) {
+  if (type === 'router' && typeof validator !== 'function') {
     logError(`
 ---------------
    Route plugin "${yellow(name)}" should have an config validator attached to '${plugin.name}'

--- a/scully/pluginManagement/pluginRepository.ts
+++ b/scully/pluginManagement/pluginRepository.ts
@@ -35,12 +35,18 @@ export const registerPlugin = (
   type: PluginTypes,
   name: string,
   plugin: any,
+  validator = async () => [],
   {replaceExistingPlugin = false} = {}
 ) => {
+  if (!['router', 'render', 'fileHandler'].includes(type)) {
+    throw new Error(
+      `Type "${yellow(type)}" is not a known plugin type for registering plugin "${yellow(name)}"`
+    );
+  }
   if (replaceExistingPlugin === false && plugins[type][name]) {
     throw new Error(`Plugin ${name} already exists`);
   }
-  if (type === 'router' && plugin[configValidator] === undefined) {
+  if (type === 'router' && configValidator === undefined) {
     logError(`
 ---------------
    Route plugin "${yellow(name)}" should have an config validator attached to '${
@@ -50,5 +56,6 @@ export const registerPlugin = (
 `);
     plugin[configValidator] = async () => [];
   }
+  plugin[configValidator] = validator;
   plugins[type][name] = plugin;
 };


### PR DESCRIPTION
To make writing plugins easier, the validator is now a parameter to the registerPlugin function.
Also the resiterPlugin functin now checks its types.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
