### PR TITLE
fix(scullyroutesservice): dont error when nor routefile is found

### DIFF
--- a/projects/scullyio/ng-lib/package.json
+++ b/projects/scullyio/ng-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/ng-lib",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "repository": {
     "type": "GIT",
     "url": "https://github.com/scullyio/scully/tree/master/projects/scullyio/ng-lib"

--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Observable, of, ReplaySubject} from 'rxjs';
-import {catchError, map, shareReplay, switchMap} from 'rxjs/operators';
+import {catchError, map, shareReplay, switchMap, filter} from 'rxjs/operators';
 import {fetchHttp} from '../utils/fetchHttp';
 
 export interface ScullyRoute {
@@ -25,6 +25,8 @@ export class ScullyRoutesService {
       );
       return of([] as ScullyRoute[]);
     }),
+    /** filter out all non-array results */
+    filter(routes => Array.isArray(routes)),
     shareReplay({refCount: false, bufferSize: 1})
   );
   available$ = this.allRoutes$.pipe(

--- a/scully/package.json
+++ b/scully/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "Scully CLI",
   "repository": {
     "type": "GIT",

--- a/scully/package.json
+++ b/scully/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "Scully CLI",
   "repository": {
     "type": "GIT",

--- a/scully/utils/defaultAction.ts
+++ b/scully/utils/defaultAction.ts
@@ -19,7 +19,6 @@ export const generateAll = async (config?: Partial<ScullyConfig>) => {
   try {
     log('Finding all routes in application.');
     const unhandledRoutes = await traverseAppRoutes();
-    console.log('hr', unhandledRoutes);
 
     if (unhandledRoutes.length < 1) {
       logWarn('No routes found in application, are you sure you installed the router? Terminating.');


### PR DESCRIPTION
When used in a specific way, the route-service coulsderror out. This fixes that issue

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
When the route file isn't created yet and is used in a specific way, it can error, and break prerendering of the page

## What is the new behavior?
doesn't error anymore, and makes sure the page renders correctly
It also removes a stray debug console.log

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

