### PR TITLE
fix(extrroutes): fix bug wehre extraroutes fails

### DIFF
--- a/scully.config.js
+++ b/scully.config.js
@@ -9,6 +9,7 @@ exports.config = {
   /** outDir is where the static distribution files end up */
   outDir: './dist/static',
   // hostName: '0.0.0.0',
+  extraRoutes: [''],
   routes: {
     '/demo/:id': {
       type: 'extra',

--- a/scully/utils/interfacesandenums.ts
+++ b/scully/utils/interfacesandenums.ts
@@ -20,7 +20,7 @@ export interface ScullyConfig {
   /** routes that needs additional processing have their configuration in here */
   routes: RouteConfig;
   /** routes that are in the application but have no route in the router */
-  extraRoutes?: string[];
+  extraRoutes?: (string | Promise<string[] | string>)[];
   /** Port-number where the original application is served */
   appPort: number;
   /** port-number where the Scully generated files are available */


### PR DESCRIPTION
When using the extraroutes option to add an empty route to render `/` scully errors out

closes #223

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Scully breaks down when adding an empty route (`""`)
Issue Number: 223

## What is the new behavior?
Works as expected, and make sure the top `index.html` gets generated

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
