### PR TITLE
fix(registerplugin): better error on type

### DIFF
--- a/scully/pluginManagement/pluginRepository.ts
+++ b/scully/pluginManagement/pluginRepository.ts
@@ -39,9 +39,12 @@ export const registerPlugin = (
   {replaceExistingPlugin = false} = {}
 ) => {
   if (!['router', 'render', 'fileHandler'].includes(type)) {
-    throw new Error(
-      `Type "${yellow(type)}" is not a known plugin type for registering plugin "${yellow(name)}"`
-    );
+    throw new Error(`
+--------------
+  Type "${yellow(type)}" is not a known plugin type for registering plugin "${yellow(name)}.
+  The first parameter of registerPlugin needs to be one of: 'fileHandler', 'router', 'render'"
+--------------
+`);
   }
   if (replaceExistingPlugin === false && plugins[type][name]) {
     throw new Error(`Plugin ${name} already exists`);

--- a/scully/pluginManagement/pluginRepository.ts
+++ b/scully/pluginManagement/pluginRepository.ts
@@ -41,8 +41,8 @@ export const registerPlugin = (
   if (!['router', 'render', 'fileHandler'].includes(type)) {
     throw new Error(`
 --------------
-  Type "${yellow(type)}" is not a known plugin type for registering plugin "${yellow(name)}.
-  The first parameter of registerPlugin needs to be one of: 'fileHandler', 'router', 'render'"
+  Type "${yellow(type)}" is not a known plugin type for registering plugin "${yellow(name)}".
+  The first parameter of registerPlugin needs to be one of: 'fileHandler', 'router', 'render'
 --------------
 `);
   }

--- a/scully/pluginManagement/systemPlugins.ts
+++ b/scully/pluginManagement/systemPlugins.ts
@@ -3,3 +3,4 @@ import '../fileHanderPlugins/asciidoc';
 import '../renderPlugins/contentRenderPlugin';
 import '../routerPlugins/jsonRoutePlugin';
 import '../routerPlugins/contentFolderPlugin';
+import '../routerPlugins/ignoredRoutePlugin';

--- a/scully/routerPlugins/ignoredRoutePlugin.ts
+++ b/scully/routerPlugins/ignoredRoutePlugin.ts
@@ -1,0 +1,7 @@
+import {registerPlugin} from '../pluginManagement/pluginRepository';
+
+/**
+ * The ignoredPlugin helps to take routes out.
+ * when you use this plugin, the route will never be rendered.
+ */
+registerPlugin('router', 'ignored', () => []);


### PR DESCRIPTION
When given the wrong type for a plugin, throw a proper explaination.

closes #219

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
The current error message isn't explanatory enough

## What is the new behavior?
throw an error like this:
```
--------------
  Type "tourer" is not a known plugin type for registering plugin "myPluginName".
  The first parameter of registerPlugin needs to be one of: 'fileHandler', 'router', 'render'
--------------
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
