### PR TITLE
fix(pupperteerrenderplugn.ts): inject scully content on  timeout

### DIFF
--- a/scully/renderPlugins/puppeteerRenderPlugin.ts
+++ b/scully/renderPlugins/puppeteerRenderPlugin.ts
@@ -41,11 +41,6 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
       /** set "running" mode */
       window['ScullyIO'] = 'running';
       window.addEventListener('AngularReady', () => {
-        /** add a small script tag to set "generated" mode */
-        const d = document.createElement('script');
-        d.innerHTML = `window['ScullyIO']='generated';`;
-        document.head.appendChild(d);
-        document.body.setAttribute('scully-version', window['scullyVersion']);
         window['onCustomEvent']();
       });
     });
@@ -54,6 +49,14 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
     await page.goto(path);
 
     await Promise.race([pageReady, waitForIt(25 * 1000)]);
+    await page.evaluate(() => {
+      /** add a small script tag to set "generated" mode */
+      const d = document.createElement('script');
+      d.innerHTML = `window['ScullyIO']='generated';`;
+      document.head.appendChild(d);
+      /** inject the scully version into the body attribute */
+      document.body.setAttribute('scully-version', window['scullyVersion']);
+    });
 
     /**
      * The stange notation is needed bcs typescript messes


### PR DESCRIPTION
closes #239

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
When a page renders after timeout body-tag and scully-generated settings are not injected

Issue Number: N/A

## What is the new behavior?
Both are updated as expected

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
