### PR TITLE
feat(traverseapparoutes): make sure there is allwyas an root Route `/`

### DIFF
--- a/scully/routerPlugins/traverseAppRoutesPlugin.ts
+++ b/scully/routerPlugins/traverseAppRoutesPlugin.ts
@@ -43,18 +43,8 @@ ${green('When there are extraRoutes in your config, we will still try to render 
   // process.exit(15);
   const allRoutes = [...routes, ...extraRoutes];
   if (allRoutes.findIndex(r => r === '') === -1) {
-    logWarn(`
-
-We did not find an empty route ({path:'', component:rootComponent}) in your app.
-This means that the root of your application will be you normal angular app, and
-is not rendered by Scully
-In some circumstances this can be cause because a redirect like:
-   ({path: '', redirectTo: 'home', pathMatch: 'full'})
-is not picked up by our scanner.
-
-${green(`By adding '' to the extraRoutes array in the scully.config option, you can bypass this issue`)}
-
-`);
+    /** make sure the root Route is always rendered. */
+    allRoutes.push('');
   }
   return allRoutes;
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
if there is no `/` route in the router, the index.html is the original version, and not rendered by Scully

Issue Number: N/A

## What is the new behavior?
The `/` route will always be rendered unless explicitly ignored by route configuration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
