### PR TITLE
fix(launchedbrowser): wait for config to be available before launch puppeteer

### DIFF
--- a/blog/page-1.md
+++ b/blog/page-1.md
@@ -5,7 +5,6 @@ publish date: 2019-11-26
 slug: look at_my-urls Cool
 slugs:
   - 'page-1'
-  - 'a slug'
 description: This is the first demo page in this sample.
 ---
 

--- a/scully.sampleBlog.config.js
+++ b/scully.sampleBlog.config.js
@@ -47,6 +47,18 @@ exports.config = {
         property: 'id',
       },
     },
+    '/user/:userId/friend/:friendCode': {
+      type: 'ignored',
+      // type:'json',
+      userId: {
+        url: 'https://jsonplaceholder.typicode.com/users',
+        property: 'id',
+      },
+      friendCode: {
+        url: 'https://jsonplaceholder.typicode.com/users?userId=${userId}',
+        property: 'id',
+      },
+    },
     '/blog/:slug': {
       type: 'contentFolder',
       // postRenderers: ['toc'],

--- a/scully/renderPlugins/puppeteerRenderPlugin.ts
+++ b/scully/renderPlugins/puppeteerRenderPlugin.ts
@@ -87,7 +87,7 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
   return pageHtml;
 };
 
-function waitForIt(milliSeconds) {
+export function waitForIt(milliSeconds) {
   return new Promise(resolve => setTimeout(() => resolve(), milliSeconds));
 }
 

--- a/scully/utils/config.ts
+++ b/scully/utils/config.ts
@@ -54,6 +54,8 @@ const loadIt = async () => {
   await updateScullyConfig(compiledConfig);
   return scullyConfig;
 };
+
+/** export the config as a promise, so you can wait for it when you need config during 'boot' */
 export const loadConfig = loadIt();
 
 export const updateScullyConfig = async (config: Partial<ScullyConfig>) => {


### PR DESCRIPTION
closes 194

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Can't config puppeteer because it is launched before config is ready
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 194

## What is the new behavior?
Make sure puppeteer is only launched after config is ready.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
