### PR TITLE
fix(transferstate): make sure it fires even on first load in lazy-loa…

### DIFF
--- a/projects/sampleBlog/src/app/user/post/post.component.html
+++ b/projects/sampleBlog/src/app/user/post/post.component.html
@@ -1,3 +1,4 @@
+<h4>Post details</h4>
 <section *ngIf="post$ | async as post">
   <h4>{{ post.title }}</h4>
 

--- a/projects/sampleBlog/src/app/user/post/post.component.ts
+++ b/projects/sampleBlog/src/app/user/post/post.component.ts
@@ -13,7 +13,7 @@ import {HttpClient} from '@angular/common/http';
 })
 export class PostComponent implements OnInit {
   postId$: Observable<number> = this.route.params.pipe(
-    pluck('post'),
+    pluck('postId'),
     filter(val => ![undefined, null].includes(val)),
     map(val => parseInt(val, 10)),
     shareReplay(1)
@@ -42,9 +42,7 @@ export class PostComponent implements OnInit {
     private route: ActivatedRoute,
     private http: HttpClient,
     private transferState: TransferStateService
-  ) {
-    console.log('post inits');
-  }
+  ) {}
 
   ngOnInit() {}
 }

--- a/projects/scullyio/ng-lib/src/lib/idleMonitor/idle-monitor.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/idleMonitor/idle-monitor.service.ts
@@ -1,7 +1,8 @@
 import {Injectable, NgZone} from '@angular/core';
-import {Router, NavigationEnd} from '@angular/router';
+import {NavigationEnd, Router} from '@angular/router';
 import {BehaviorSubject} from 'rxjs';
-import {filter, map, tap, startWith, shareReplay, pluck, take} from 'rxjs/operators';
+import {filter, pluck, take, tap} from 'rxjs/operators';
+import {TransferStateService} from '../transfer-state/transfer-state.service';
 
 // tslint:disable-next-line: no-any
 // tslint:disable: no-string-literal
@@ -26,7 +27,7 @@ export class IdleMonitorService {
   private appReady = new Event('AngularReady', {bubbles: true, cancelable: false});
   private appTimeout = new Event('AngularTimeout', {bubbles: true, cancelable: false});
 
-  constructor(private zone: NgZone, private router: Router) {
+  constructor(private zone: NgZone, private router: Router, private tss: TransferStateService) {
     if (window) {
       window.dispatchEvent(this.initApp);
       this.router.events


### PR DESCRIPTION
…ded module

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
If you use getState for the first time in a lazy-loaded component, its state is not there.

## What is the new behavior?
The state from getState is always loaded correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Right now, we are booting the `transferStateService` on app boot, even of there is no use of `getState` at all.

