### PR TITLE
feat(scully runtime config): user forRoot to pass config to Scully

### DIFF
--- a/projects/sampleBlog/src/app/app.module.ts
+++ b/projects/sampleBlog/src/app/app.module.ts
@@ -7,7 +7,12 @@ import {AppComponent} from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, HttpClientModule, AppRoutingModule, ScullyLibModule],
+  imports: [
+    BrowserModule,
+    HttpClientModule,
+    AppRoutingModule,
+    ScullyLibModule.forRoot({useTranferState: true}),
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/projects/scullyio/ng-lib/src/lib/config/scully-config.ts
+++ b/projects/scullyio/ng-lib/src/lib/config/scully-config.ts
@@ -5,7 +5,7 @@ export interface ScullyLibConfig {
 }
 
 export const ScullyDefaultSettings: ScullyLibConfig = {
-  useTranferState: false,
+  useTranferState: true,
 };
 
 export const SCULLY_LIB_CONFIG = new InjectionToken<ScullyLibConfig>('scullyLibConfig', {

--- a/projects/scullyio/ng-lib/src/lib/config/scully-config.ts
+++ b/projects/scullyio/ng-lib/src/lib/config/scully-config.ts
@@ -1,0 +1,13 @@
+import {InjectionToken} from '@angular/core';
+
+export interface ScullyLibConfig {
+  useTranferState: boolean;
+}
+
+export const ScullyDefaultSettings: ScullyLibConfig = {
+  useTranferState: false,
+};
+
+export const SCULLY_LIB_CONFIG = new InjectionToken<ScullyLibConfig>('scullyLibConfig', {
+  factory: () => ScullyDefaultSettings,
+});

--- a/projects/scullyio/ng-lib/src/lib/idleMonitor/idle-monitor.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/idleMonitor/idle-monitor.service.ts
@@ -1,8 +1,10 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Inject, Injectable, NgZone} from '@angular/core';
 import {NavigationEnd, Router} from '@angular/router';
 import {BehaviorSubject} from 'rxjs';
 import {filter, pluck, take, tap} from 'rxjs/operators';
+import {ScullyLibConfig, SCULLY_LIB_CONFIG} from '../config/scully-config';
 import {TransferStateService} from '../transfer-state/transfer-state.service';
+import {isScullyRunning} from '../utils/isScully';
 
 // tslint:disable-next-line: no-any
 // tslint:disable: no-string-literal
@@ -27,8 +29,13 @@ export class IdleMonitorService {
   private appReady = new Event('AngularReady', {bubbles: true, cancelable: false});
   private appTimeout = new Event('AngularTimeout', {bubbles: true, cancelable: false});
 
-  constructor(private zone: NgZone, private router: Router, private tss: TransferStateService) {
-    if (window) {
+  constructor(
+    private zone: NgZone,
+    private router: Router,
+    @Inject(SCULLY_LIB_CONFIG) conf: ScullyLibConfig,
+    tss: TransferStateService
+  ) {
+    if (window && isScullyRunning()) {
       window.dispatchEvent(this.initApp);
       this.router.events
         .pipe(
@@ -36,6 +43,10 @@ export class IdleMonitorService {
           tap(() => this.zoneIdleCheck())
         )
         .subscribe();
+    }
+    if (conf && conf.useTranferState) {
+      /** don't start monitoring if people don't use the transferState */
+      tss.startMonitoring();
     }
   }
 

--- a/projects/scullyio/ng-lib/src/lib/scully-lib.module.ts
+++ b/projects/scullyio/ng-lib/src/lib/scully-lib.module.ts
@@ -1,4 +1,5 @@
-import {NgModule} from '@angular/core';
+import {ModuleWithProviders, NgModule} from '@angular/core';
+import {ScullyDefaultSettings, ScullyLibConfig, SCULLY_LIB_CONFIG} from './config/scully-config';
 import {IdleMonitorService} from './idleMonitor/idle-monitor.service';
 import {ScullyContentModule} from './scully-content/scully-content.module';
 
@@ -14,5 +15,11 @@ export class ScullyLibModule {
    * there will be only 1 instance in our app.
    * We don't need forRoot, as we are not configuring anything in here.
    */
+  static forRoot(config: ScullyLibConfig = ScullyDefaultSettings): ModuleWithProviders {
+    return {
+      ngModule: ScullyLibModule,
+      providers: [{provide: SCULLY_LIB_CONFIG, useValue: config}],
+    };
+  }
   constructor(private idle: IdleMonitorService) {}
 }


### PR DESCRIPTION
The transferState service now only gets activated when the config using forRoot says so.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
`transferStateService` is always monitoring the route, and trying to load data, even when `s/getState` is not used at all.

## What is the new behavior?
`transferStateService` is only monitoring if the user tells it so by using the config in forRoot
like this:
```typescript
@NgModule({
  declarations: [AppComponent],
  imports: [
    BrowserModule,
    HttpClientModule,
    AppRoutingModule,
    ScullyLibModule.forRoot({useTranferState: true}),
  ],
  bootstrap: [AppComponent],
})
export class AppModule {}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
