### PR TITLE
fix(hosturl): fix hostURL so the our internal server is not started, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Scully
 
+[![](./assets/logos/PNG/scullyio-logo.png)]()
+
 [![GitHub](https://img.shields.io/github/license/scullyio/scully)](https://github.com/scullyio/scully/blob/master/LICENSE)
 [![Gitter](https://img.shields.io/gitter/room/scullyio/community)](https://gitter.im/scullyio/community)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)

--- a/scully.sampleBlog.config.js
+++ b/scully.sampleBlog.config.js
@@ -7,6 +7,7 @@ exports.config = {
   /** outDir is where the static distribution files end up */
   outDir: './dist/static',
   // hostName: '0.0.0.0',
+  hostUrl: 'http://localHost:5000',
   extraRoutes: [''],
   routes: {
     '/demo/:id': {

--- a/scully/routerPlugins/traverseAppRoutesPlugin.ts
+++ b/scully/routerPlugins/traverseAppRoutesPlugin.ts
@@ -42,9 +42,9 @@ ${green('When there are extraRoutes in your config, we will still try to render 
   }
   // process.exit(15);
   const allRoutes = [...routes, ...extraRoutes];
-  if (allRoutes.findIndex(r => r === '') === -1) {
+  if (allRoutes.findIndex(r => r.trim() === '' || r.trim() === '/') === -1) {
     /** make sure the root Route is always rendered. */
-    allRoutes.push('');
+    allRoutes.push('/');
   }
   return allRoutes;
 };

--- a/scully/utils/cache.ts
+++ b/scully/utils/cache.ts
@@ -1,0 +1,2 @@
+export const rawRoutesCache = new Set<string>();
+export const flushRawRoutesCache = () => rawRoutesCache.clear();

--- a/scully/utils/defaultAction.ts
+++ b/scully/utils/defaultAction.ts
@@ -12,6 +12,7 @@ import {chunk} from './chunk';
 import {loadConfig} from './config';
 import {log, logWarn} from './log';
 import {performanceIds} from './performanceIds';
+import {rawRoutesCache} from './cache';
 
 export const {baseFilter} = yargs
   .string('bf')
@@ -19,22 +20,20 @@ export const {baseFilter} = yargs
   .default('bf', '')
   .describe('bf', 'provide a minimatch glob for the unhandled routes').argv;
 
-const cache = new Set<string>();
-
 console.log(baseFilter);
 export const generateAll = async (localBaseFilter = baseFilter) => {
   await loadConfig;
   try {
     let unhandledRoutes;
-    if (cache.size == 0) {
+    if (rawRoutesCache.size === 0) {
       log('Finding all routes in application.');
       performance.mark('startTraverse');
       unhandledRoutes = await traverseAppRoutes();
       performance.mark('stopTraverse');
       performanceIds.add('Traverse');
-      unhandledRoutes.forEach(r => cache.add(r));
+      unhandledRoutes.forEach(r => rawRoutesCache.add(r));
     } else {
-      unhandledRoutes = [...cache.keys()];
+      unhandledRoutes = [...rawRoutesCache.keys()];
     }
 
     if (unhandledRoutes.length < 1) {
@@ -46,7 +45,7 @@ export const generateAll = async (localBaseFilter = baseFilter) => {
     performanceIds.add('Discovery');
     log('Pull in data to create additional routes.');
     const handledRoutes = await addOptionalRoutes(
-      unhandledRoutes.filter((r: string) => r && r.startsWith(localBaseFilter))
+      unhandledRoutes.filter((r: string) => typeof r === 'string' && r.startsWith(localBaseFilter))
     );
     performance.mark('stopDiscovery');
     /** save routerinfo, so its available during rendering */


### PR DESCRIPTION
…and we are requiring

don't start the internal server, and use the given one from `hostUrl`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Internal server starts and the program fails to connect to an external server

## What is the new behavior?
Don't start the internal server, and use the external server only

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Note that this doesn't check if the server is available, or is running in the current project. As it's a 3rth party server, we don't have control over this.
