### PR TITLE
fix(scully.ts): supprt SSL on kill and launch

### DIFF
--- a/scully/scully.ts
+++ b/scully/scully.ts
@@ -7,6 +7,7 @@ import {readFileSync} from 'fs-extra';
 import {join} from 'path';
 import './pluginManagement/systemPlugins';
 import {startBackgroundServer} from './startBackgroundServer';
+import {hostName, openNavigator, removeStaticDist, ssl, watch} from './utils/cli-options';
 import {loadConfig} from './utils/config';
 import {moveDistAngular} from './utils/fsAngular';
 import {httpGetJson} from './utils/httpGetJson';
@@ -15,7 +16,6 @@ import {logError, logWarn, yellow} from './utils/log';
 import {startScully} from './utils/startup';
 import {waitForServerToBeAvailable} from './utils/waitForServerToBeAvailable';
 import {bootServe, isBuildThere, watchMode} from './watchMode';
-import {watch, removeStaticDist, openNavigator, hostName, ssl} from './utils/cli-options';
 const open = require('open');
 
 /** the default of 10 is too shallow for generating pages. */
@@ -37,9 +37,9 @@ if (process.argv.includes('version')) {
     await httpGetJson(`http://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
       suppressErrors: true,
     }).catch(e => e);
-    await httpGetJson(`https://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`).catch(e =>
-      console.error(e)
-    );
+    await httpGetJson(`https://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
+      suppressErrors: true,
+    }).catch(e => e);
     logWarn('Sended kill command to server');
     process.exit(0);
     return;

--- a/scully/scully.ts
+++ b/scully/scully.ts
@@ -15,7 +15,7 @@ import {logError, logWarn, yellow} from './utils/log';
 import {startScully} from './utils/startup';
 import {waitForServerToBeAvailable} from './utils/waitForServerToBeAvailable';
 import {bootServe, isBuildThere, watchMode} from './watchMode';
-import {watch, removeStaticDist, openNavigator, hostName} from './utils/cli-options';
+import {watch, removeStaticDist, openNavigator, hostName, ssl} from './utils/cli-options';
 const open = require('open');
 
 /** the default of 10 is too shallow for generating pages. */
@@ -37,6 +37,9 @@ if (process.argv.includes('version')) {
     await httpGetJson(`http://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
       suppressErrors: true,
     });
+    await httpGetJson(`https://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
+      suppressErrors: true,
+    });
     process.exit(0);
     return;
   }
@@ -45,7 +48,7 @@ if (process.argv.includes('version')) {
   if (process.argv.includes('serve')) {
     await bootServe(scullyConfig);
     if (openNavigator) {
-      await open(`http://${scullyConfig.hostName}:${scullyConfig.staticport}/`);
+      await open(`http${ssl ? 's' : ''}://${scullyConfig.hostName}:${scullyConfig.staticport}/`);
     }
   } else {
     const folder = join(scullyConfig.homeFolder, scullyConfig.distFolder);
@@ -71,7 +74,7 @@ You are using "${yellow(scullyConfig.hostUrl)}" as server.
       }
     }
     if (openNavigator) {
-      await open(`http://${scullyConfig.hostName}:${scullyConfig.staticport}/`);
+      await open(`http${ssl ? 's' : ''}://${scullyConfig.hostName}:${scullyConfig.staticport}/`);
     }
     if (watch) {
       watchMode(
@@ -83,7 +86,7 @@ You are using "${yellow(scullyConfig.hostUrl)}" as server.
       await startScully();
       if (!isTaken && typeof scullyConfig.hostUrl !== 'string') {
         // kill serve ports
-        await httpGetJson(`http://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
+        await httpGetJson(`http${ssl ? 's' : ''}://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
           suppressErrors: true,
         });
       }

--- a/scully/scully.ts
+++ b/scully/scully.ts
@@ -36,10 +36,11 @@ if (process.argv.includes('version')) {
   if (process.argv.includes('killServer')) {
     await httpGetJson(`http://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
       suppressErrors: true,
-    });
-    await httpGetJson(`https://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`, {
-      suppressErrors: true,
-    });
+    }).catch(e => e);
+    await httpGetJson(`https://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`).catch(e =>
+      console.error(e)
+    );
+    logWarn('Sended kill command to server');
     process.exit(0);
     return;
   }

--- a/scully/utils/httpGetJson.ts
+++ b/scully/utils/httpGetJson.ts
@@ -9,6 +9,8 @@ export function httpGetJson(
     headers: {},
   }
 ) {
+  // tslint:disable-next-line:no-string-literal
+  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
   const httpGet = url.toLowerCase().includes('https:') ? getHttps : get;
   return new Promise((resolve, reject) => {
     const {pathname, hostname, port, protocol, search, hash} = new URL(url);

--- a/scully/utils/staticServer.ts
+++ b/scully/utils/staticServer.ts
@@ -5,7 +5,7 @@ import {ssl, tds} from '../utils/cli-options';
 import {addSSL} from './addSSL';
 import {scullyConfig} from './config';
 import {startDataServer} from './dataServer';
-import {log, logError, yellow} from './log';
+import {log, logError, yellow, logWarn} from './log';
 import {proxyAdd} from './proxyAdd';
 
 let angularServerInstance: {close: () => void};
@@ -51,8 +51,10 @@ export async function staticServer(port?: number) {
       res.json({res: true, homeFolder: scullyConfig.homeFolder});
     });
     angularDistServer.get('/killMe', async (req, res) => {
+      logWarn('Received Kill command');
       await res.json({ok: true});
       await closeExpress();
+      logWarn('Closed servers');
       process.exit(0);
     });
     /** use express to serve all static assets in dist folder. */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
When using the SSL option, the killserver nor the --open will not work

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
both are working now

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
