### PR TITLE
feat(scully): add contentType to contentFolderPlugin route data

### DIFF
--- a/scully/routerPlugins/contentFolderPlugin.ts
+++ b/scully/routerPlugins/contentFolderPlugin.ts
@@ -73,6 +73,14 @@ async function addHandleRoutes(sourceFile, baseRoute, templateFile, conf, ext) {
     templateFile,
     data: {...meta, sourceFile},
   };
+
+  // Add contentType value for filtering purposes
+  const contentFolderParts = conf.slug.folder.split('/');
+  const contentType = contentFolderParts[contentFolderParts.length - 1];
+  if (contentType) {
+    handledRoute.data.contentType = contentType;
+  }
+
   handledRoutes.push(handledRoute);
   if (!prePublished && Array.isArray(meta.slugs)) {
     /** also add routes for all available slugs */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

contentType must be inferred from route in the route data when iterating routes in a page. Example: `news` and `media`(screenshots, videos, etc) types may both exist. On the news index page we would want to filter for only `news` posts.

Issue Number: N/A

## What is the new behavior?

The new behavior adds a `contentType` field to the route data. This is extracted from the `route.slug.folder`. 

Is there a better place to extract this value?

Is there a more preferred name for the property instead of `contentType`?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
