### PR TITLE
DRAFT: feat(schematics): add list page for markdown schematic

### DIFF
--- a/schematics/scully/src/create-markdown/index.ts
+++ b/schematics/scully/src/create-markdown/index.ts
@@ -67,7 +67,12 @@ const addModule = (options: Schema) => (tree: Tree, context: SchematicContext) =
     addRouteToModule(tree, options);
   }
 
-  return applyWithOverwrite(url('../files/markdown-module'), [
+  let templatePath = '../files/markdown-module';
+  if (options.includeListPage) {
+    templatePath = '../files/markdown-with-list-page-module';
+  }
+
+  return applyWithOverwrite(url(templatePath), [
     applyTemplates({
       classify: strings.classify,
       dasherize: strings.dasherize,

--- a/schematics/scully/src/create-markdown/schema.json
+++ b/schematics/scully/src/create-markdown/schema.json
@@ -32,6 +32,11 @@
       "description": "define the route where your post will be available",
       "x-prompt": "Under which route do you want your files to be requested?"
     },
+    "includeListPage": {
+      "type": "boolean",
+      "description": "add a list page",
+      "x-prompt": "Would you like to generate a list page as well?"
+    },
     "project": {
       "type": "string",
       "description": "add the project",

--- a/schematics/scully/src/create-markdown/schema.ts
+++ b/schematics/scully/src/create-markdown/schema.ts
@@ -20,4 +20,9 @@ export interface Schema {
    */
   route?: string;
   project: string;
+
+  /*
+   * add a list page
+   */
+  includeListPage?: boolean;
 }

--- a/schematics/scully/src/files/markdown-with-list-page-module/__name@dasherize__-routing.module.ts.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/__name@dasherize__-routing.module.ts.template
@@ -1,0 +1,26 @@
+import {NgModule} from '@angular/core';
+import {Routes, RouterModule} from '@angular/router';
+
+import {<%= classify(name) %>Component} from './post/<%= dasherize(name) %>.component';
+import {<%= classify(name) %>PageComponent} from './page/<%= dasherize(name) %>-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: <%= classify(name) %>PageComponent,
+  },
+  {
+    path: ':<%= dasherize(slug) %>',
+    component: <%= classify(name) %>Component,
+  },
+  {
+    path: '**',
+    component: <%= classify(name) %>PageComponent,
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class <%= classify(name) %>RoutingModule {}

--- a/schematics/scully/src/files/markdown-with-list-page-module/__name@dasherize__.module.ts.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/__name@dasherize__.module.ts.template
@@ -1,0 +1,12 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ScullyLibModule} from '@scullyio/ng-lib';
+import {<%= classify(name) %>RoutingModule} from './<%= dasherize(name) %>-routing.module';
+import {<%= classify(name) %>Component} from './post/<%= dasherize(name) %>.component';
+import {<%= classify(name) %>PageComponent} from './page/<%= dasherize(name) %>-page.component';
+
+@NgModule({
+  declarations: [<%= classify(name) %>Component, <%= classify(name) %>PageComponent],
+  imports: [CommonModule, <%= classify(name) %>RoutingModule, ScullyLibModule],
+})
+export class <%= classify(name) %>Module {}

--- a/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.css.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.css.template
@@ -1,0 +1,10 @@
+
+
+ ::slotted(h1)  {
+  color:rgb(51, 6, 37);
+  background-color: rgb(248, 211, 236);
+  padding: 5px;
+  border-radius: 5px;
+  width: fit-content;
+}
+

--- a/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.html.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.html.template
@@ -1,0 +1,5 @@
+<h1>ScullyIo <%= classify(name) %> List content</h1>
+
+<div *ngFor="let <%= camelize(name) %>Post of <%= camelize(name) %>Posts">
+  <a [routerLink]="<%= camelize(name) %>Post.route">{{ <%= camelize(name) %>Post.route }}</a>
+</div>

--- a/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.spec.ts.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.spec.ts.template
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { <%= classify(name) %>PageComponent } from './<%= dasherize(name) %>-page.component';
+
+describe('<%= classify(name) %>PageComponent', () => {
+  let component: <%= classify(name) %>PageComponent;
+  let fixture: ComponentFixture<<%= classify(name) %>PageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ <%= classify(name) %>PageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(<%= classify(name) %>PageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.ts.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/page/__name@dasherize__-page.component.ts.template
@@ -1,0 +1,27 @@
+import {Component, OnInit, ViewEncapsulation} from '@angular/core';
+import {ActivatedRoute, Router, ROUTES} from '@angular/router';
+import { ScullyRoutesService } from '@scullyio/ng-lib';
+
+declare var ng: any;
+
+@Component({
+  selector: '<%= prefix %>-<%= dasherize(name) %>',
+  templateUrl: './<%= dasherize(name) %>-page.component.html',
+  styleUrls: ['./<%= dasherize(name) %>-page.component.css'],
+  preserveWhitespaces: true,
+  encapsulation: ViewEncapsulation.Emulated
+
+})
+export class <%= classify(name) %>PageComponent implements OnInit {
+
+  <%= camelize(name) %>Posts: any[] = [];
+
+  ngOnInit() {
+    this.scully.available$.subscribe(links => {
+      this.<%= camelize(name) %>Posts = links.filter(link => link.route.startsWith('/<%= camelize(name) %>/'));
+    });
+  }
+
+  constructor(private router: Router, private route: ActivatedRoute, private scully: ScullyRoutesService) {
+  }
+}

--- a/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.css.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.css.template
@@ -1,0 +1,10 @@
+
+
+ ::slotted(h1)  {
+  color:rgb(51, 6, 37);
+  background-color: rgb(248, 211, 236);
+  padding: 5px;
+  border-radius: 5px;
+  width: fit-content;
+}
+

--- a/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.html.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.html.template
@@ -1,0 +1,7 @@
+<h3>ScullyIo <%= classify(name) %> content</h3>
+<hr>
+
+<!-- This is where Scully will inject the static HTML -->
+<scully-content></scully-content>
+<hr>
+<h4>End of content</h4>

--- a/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.spec.ts.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.spec.ts.template
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { <%= classify(name) %>Component } from './<%= classify(name) %>.component';
+
+describe('<%= classify(name) %>Component', () => {
+  let component: <%= classify(name) %>Component;
+  let fixture: ComponentFixture<<%= classify(name) %>Component>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ <%= classify(name) %>Component ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(<%= classify(name) %>Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.ts.template
+++ b/schematics/scully/src/files/markdown-with-list-page-module/post/__name@dasherize__.component.ts.template
@@ -1,0 +1,19 @@
+import {Component, OnInit, ViewEncapsulation} from '@angular/core';
+import {ActivatedRoute, Router, ROUTES} from '@angular/router';
+
+declare var ng: any;
+
+@Component({
+  selector: '<%= prefix %>-<%= dasherize(name) %>',
+  templateUrl: './<%= dasherize(name) %>.component.html',
+  styleUrls: ['./<%= dasherize(name) %>.component.css'],
+  preserveWhitespaces: true,
+  encapsulation: ViewEncapsulation.Emulated
+
+})
+export class <%= classify(name) %>Component implements OnInit {
+  ngOnInit() {}
+
+  constructor(private router: Router, private route: ActivatedRoute) {
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The markdown schematic only scaffolds files needed for posts.

Issue Number: N/A

## What is the new behavior?

The markdown schematic scaffolds a list page along with the post code.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is an initial PR to feel out how this should be implemented. Creating a new set of templates and modifying the existing `markdown` schematic seems like the least amount of change to get the idea across.

I would be happy to refactor these changes to match more closely with what you would prefer after we have discussed the implementation details more. Tests and documentation updates would follow as needed, as well.