### PR TITLE
refactor(ng-lib): change cleanDups to private

### DIFF
--- a/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -68,7 +68,7 @@ export class ScullyRoutesService {
     );
   }
 
-  cleanDups(routes: ScullyRoute[]) {
+  private cleanDups(routes: ScullyRoute[]) {
     const m = new Map<string, ScullyRoute>();
     routes.forEach(r => m.set(r.sourceFile || r.route, r));
     return [...m.values()];


### PR DESCRIPTION
change cleanDups to private as it's an implementation detail

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

`cleanDups` is publicly accessible but meant to be an implementation detail as stated by @SanderElias on Gitter : 

> the cleandups is private, it is an implementation detail. (as content-routes can have multiple instances this makes sure they are not leaking into the app, wreaking havoc on lists)


## What is the new behavior?

`cleanDups` is no longer accessible

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No