### PR TITLE
feat(scully): name option for contentfolderplugin

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/scully/routerPlugins/contentFolderPlugin.ts
+++ b/scully/routerPlugins/contentFolderPlugin.ts
@@ -67,11 +67,12 @@ async function addHandleRoutes(sourceFile, baseRoute, templateFile, conf, ext) {
   }
   // is a folder we need iterate the content in the folder
   const {meta, prePublished} = await readFileAndCheckPrePublishSlug(templateFile);
+  const name = conf.name;
   const handledRoute: HandledRoute = {
     route: routify(meta.slug || base),
     type: conf.type,
     templateFile,
-    data: {...meta, sourceFile},
+    data: {name, ...meta, sourceFile},
   };
   handledRoutes.push(handledRoute);
   if (!prePublished && Array.isArray(meta.slugs)) {


### PR DESCRIPTION
this adds a way to differentiate between different contentfolders

ISSUES CLOSED: #320

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
