### PR TITLE
feat(schematics): add meta tag generator to the index.html file

### DIFF
--- a/schematics/scully/package.json
+++ b/schematics/scully/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@angular-devkit/core": "^9.0.0-rc.5",
     "@angular-devkit/schematics": "^9.0.0-rc.5",
+    "@angular/cdk": "^9.0.0-rc.5",
     "@schematics/angular": "^9.0.0-rc.5",
     "js-yaml": "^3.13.1",
     "schematics-utilities": "^2.0.0"

--- a/schematics/scully/src/scully/index.ts
+++ b/schematics/scully/src/scully/index.ts
@@ -1,9 +1,20 @@
 import {Rule, SchematicContext, Tree, SchematicsException, chain} from '@angular-devkit/schematics';
+import {
+  appendHtmlElementToHead,
+  getProjectIndexFiles,
+  getProjectFromWorkspace,
+} from '@angular/cdk/schematics';
 import {getSrc, getPackageJson, overwritePackageJson, getProject, checkProjectExist} from '../utils/utils';
+import {getWorkspace} from '@schematics/angular/utility/config';
 import {Schema} from '../ng-add/schema';
 
 export default (options: any): Rule => {
-  return chain([verifyAngularWorkspace(), modifyPackageJson(options), createScullyConfig(options)]);
+  return chain([
+    verifyAngularWorkspace(),
+    modifyPackageJson(options),
+    createScullyConfig(options),
+    updateIndexFile(options),
+  ]);
 };
 
 const verifyAngularWorkspace = () => (tree: Tree, context: SchematicContext) => {
@@ -43,4 +54,20 @@ const createScullyConfig = (options: Schema) => (tree: Tree, context: SchematicC
     );
     context.logger.info(`✅️ Created scully configuration file in ${scullyConfigFile}`);
   }
+};
+
+const updateIndexFile = (options: Schema) => (tree: Tree, context: SchematicContext) => {
+  const workspace = getWorkspace(tree);
+  const projectName = options.project === 'defaultProject' ? '' : getProject(tree, options.project);
+  const project = getProjectFromWorkspace(workspace, projectName);
+  const projectIndexFiles = getProjectIndexFiles(project);
+
+  if (!projectIndexFiles.length) {
+    throw new SchematicsException('No project index HTML file could be found.');
+  }
+  const metaTag = '<meta name="generator" content="Scully" />';
+  projectIndexFiles.forEach(indexFilePath => {
+    appendHtmlElementToHead(tree, indexFilePath, metaTag);
+    context.logger.info(`✅️ Pride added to ${indexFilePath}`);
+  });
 };

--- a/schematics/scully/src/scully/index_spec.ts
+++ b/schematics/scully/src/scully/index_spec.ts
@@ -8,6 +8,7 @@ import {setupProject} from '../utils/test-utils';
 const collectionPath = path.join(__dirname, '../collection.json');
 const PACKAGE_JSON_PATH = '/package.json';
 const SCULLY_PATH = '/scully.config.js';
+const INDEX_PATH = '/src/index.html';
 
 describe('scully schematic', () => {
   const schematicRunner = new SchematicTestRunner('scully-schematics', collectionPath);
@@ -64,6 +65,12 @@ describe('scully schematic', () => {
       appTree = await schematicRunner.runSchematicAsync('scully', defaultOptions, appTree).toPromise();
       expect(appTree.files).toContain(PACKAGE_JSON_PATH);
       expect(getFileContent(appTree, SCULLY_PATH)).toEqual('foo');
+    });
+
+    it(`should index.html includes meta tag generator'`, async () => {
+      expect(appTree.files).toContain(INDEX_PATH);
+      const scullyConfFile = getFileContent(appTree, INDEX_PATH);
+      expect(scullyConfFile.includes('<meta name="generator" content="Scully" />')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

When the user runs ```ng add @scullyio/init``` the schematic now adds the meta tag ```name=generator``` with the ```content=Scully```.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
