### PR TITLE
docs: update docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,6 @@ If the installation was successful a message similar to this one will be display
 ```bash
 Installed packages for tooling via yarn.
 ✔ Added dependency
-✔ Import HttpClientModule into root module
 UPDATE package.json (1447 bytes)
 UPDATE src/app/app.module.ts (472 bytes)
 UPDATE src/polyfills.ts (3035 bytes)

--- a/docs/getting-started_es.md
+++ b/docs/getting-started_es.md
@@ -42,7 +42,6 @@ Si la instalación fue exitosa, se mostrará un mensaje similar a este:
 ```bash
 Installed packages for tooling via yarn.
 ✔ Added dependency
-✔ Import HttpClientModule into root module
 UPDATE package.json (1447 bytes)
 UPDATE src/app/app.module.ts (472 bytes)
 UPDATE src/polyfills.ts (3035 bytes)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,10 +3,11 @@
 Scully uses a plugin system to allow users to define new ways for Scully to pre-render your app. There are three main
 types of plugins:
 
-1. [Register Plugin](#register-plugin)
 1. [Router Plugins](#router-plugin)
 1. [Render Plugins](#render-plugin)
 1. [File Handler Plugins](#file-plugin)
+
+See [how to register a plugin](#register-plugin).
 
 See our [Recommended Plugins](recommended-plugins.md) page to find a list of available plugins.
 

--- a/schematics/scully/src/ng-add/index_spec.ts
+++ b/schematics/scully/src/ng-add/index_spec.ts
@@ -45,12 +45,6 @@ describe('ng-add schematic', () => {
       expect(dependencies['@scullyio/scully']).toEqual(scullyComponentVersion);
     });
 
-    it('should add the HttpClientModule', () => {
-      const appModuleContent = getFileContent(appTree, 'src/app/app.module.ts');
-      expect(appModuleContent).toMatch(/import.*HttpClientModule.*from.*\@angular\/common\/http/g);
-      expect(appModuleContent).toMatch(/imports.*:.*\[.*HttpClientModule\s+\]/s);
-    });
-
     it('should add the polyfill', () => {
       const appModuleContent = getFileContent(appTree, 'src/polyfills.ts');
       expect(appModuleContent).toMatch(/import.*zone\.js\/dist\/task-tracking/g);


### PR DESCRIPTION
remove HttpClientModule reference
remove HttpClientModule test
move plugin registration out of the list

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: update documentation

## What is the current behavior?

`HttpClientModule` is not added anymore using `ng add @scullyio/init`.
There is still a test to check if `HttpClientModule` has been added to `AppModule`.

The link to the section about `how to register plugin` is misleading as being part of a list previously stated as a list of three plugins (router, render, file handler).

## What is the new behavior?

The `HttpClientModule` reference has been removed from the output message sample.
The corresponding test is removed.

The link to `how to register plugin` has been moved out of the list.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
