### PR TITLE
fix: slug folder

### DIFF
--- a/scully/utils/fsFolder.ts
+++ b/scully/utils/fsFolder.ts
@@ -20,7 +20,7 @@ export async function checkStaticFolder() {
         for (const slug in config[property]) {
           if (config[property][slug].folder !== undefined) {
             // @ts-ignore
-            const fileName = config[property].slug.folder.replace('./', '');
+            const fileName = config[property][slug].folder.replace('./', '');
             if (!folder.find(f => f === fileName)) {
               folder.push(fileName);
               if (existFolder(fileName)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

In watch mode the folder location should point to the variable "slug" not the explicit folder "slug".

For example with a config settings: 
```js
exports.config = {
  projectRoot: "./src",
  projectName: "my-scully-blog",
  outDir: "./dist/static",
  routes: {
    "/blog/:postId": {
      type: "contentFolder",
      postId: {
        folder: "./blog"
      }
    }
  }
};
``` 

and after `npm run scully` you will receive the following error:

```
error into read the config TypeError: Cannot read property 'folder' of undefined
    at Object.checkStaticFolder (/Users/jiverson/dev/my-scully-blog/node_modules/@scullyio/scully/utils/fsFolder.js:24:64)
    at Object.watchMode (/Users/jiverson/dev/my-scully-blog/node_modules/@scullyio/scully/watchMode.js:37:22)
    at /Users/jiverson/dev/my-scully-blog/node_modules/@scullyio/scully/scully.js:84:25
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
If you run in `npm run scully --nw` everything works.