### PR TITLE
feat(scully): make getHandledRoutes promise available

### DIFF
--- a/scully/index.ts
+++ b/scully/index.ts
@@ -8,6 +8,7 @@ import {RouteTypes, ScullyConfig} from './utils/interfacesandenums';
 import {replaceFirstRouteParamWithVal} from './utils/replaceFirstRouteParamWithVal';
 import {routeSplit} from './utils/routeSplit';
 import {startScully} from './utils/startup';
+import {getHandledRoutes} from './utils/services/routeStorage';
 
 export * from './utils/log';
 export {
@@ -23,4 +24,5 @@ export {
   ScullyConfig,
   startScully,
   updateScullyConfig,
+  getHandledRoutes,
 };

--- a/scully/utils/services/routeStorage.ts
+++ b/scully/utils/services/routeStorage.ts
@@ -1,0 +1,11 @@
+import {registerPlugin} from '../../pluginManagement/pluginRepository';
+import {HandledRoute} from '../../routerPlugins/addOptionalRoutesPlugin';
+
+let resolveRoutes: (value?: HandledRoute[] | PromiseLike<HandledRoute[]>) => void;
+export const getHandledRoutes: Promise<HandledRoute[]> = new Promise(resolve => (resolveRoutes = resolve));
+
+const storeRoutesPlugin = async routes => {
+  resolveRoutes(routes);
+};
+
+registerPlugin('routeDiscoveryDone', 'storeRoutes', storeRoutesPlugin);


### PR DESCRIPTION
with thsi PR you can get the full list of routes when you need it. It is only available _after_ the
routeDetection phase is done.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #374 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
