### PR TITLE
feat(scully): add 404.html to redirect to.

### DIFF
--- a/scully/package.json
+++ b/scully/package.json
@@ -20,7 +20,7 @@
     "express": "^4.17.1",
     "front-matter": "^3.0.2",
     "fs-extra": "^9.0.0",
-    "guess-parser": "^0.4.15",
+    "guess-parser": "^0.4.17",
     "jsdom": "^16.2.1",
     "jsonc": "2.0.0",
     "marked": "^0.8.1",

--- a/scully/utils/fsAngular.ts
+++ b/scully/utils/fsAngular.ts
@@ -8,6 +8,8 @@ import {baseFilter} from './cli-options';
 import {scullyConfig} from './config';
 import {createFolderFor} from './createFolderFor';
 import {green, log, logWarn} from './log';
+import {createOptimisticUniqueName} from 'typescript';
+import {existFolder} from './fsFolder';
 
 export async function checkChangeAngular(
   folder = join(scullyConfig.homeFolder, scullyConfig.distFolder) ||
@@ -67,6 +69,12 @@ export async function moveDistAngular(src, dest, {reset = true, removeStaticDist
     // make sure the static folder exists
     createFolderFor(dest);
     await copy(src, dest);
+    const source404 = join(src, 'index.html');
+    const page404 = join(dest, '404.html');
+    if (!existFolder(page404)) {
+      /** only add a 404 if there isn't one */
+      await copy(source404, page404);
+    }
     log(`${green(` ☺  `)} new Angular build imported`);
     if (reset) {
       restartStaticServer();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
No 404 file

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #361 

## What is the new behavior?
Copies the `index.html` (the original angular app) to `404.html`  when that doesn't exist. You can now redirect your server to this file if there is no route file available.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
