### PR TITLE
feat(scully): add support to set the number of cores during rendering,

### DIFF
--- a/docs/scully-provided-plugins.md
+++ b/docs/scully-provided-plugins.md
@@ -1,0 +1,24 @@
+---
+title: Scully system plugins
+order: 700
+---
+
+# This document descrobes the plugins that are build into scully.
+
+## json (router)
+
+## ignored (router)
+
+## contentFolder (router+render)
+
+## seoHrefOptimise (render)
+
+Adds an trailing slash (`/`) to all routes that are in the routeService. Increases SEO scoring
+
+## adoc (fileHandler)
+
+## md (fileHandler)
+
+## default
+
+The default routing plugin. Does add the route verbatim.

--- a/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -1,7 +1,7 @@
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable} from '@angular/core';
 import {NavigationEnd, NavigationStart, Router} from '@angular/router';
-import {BehaviorSubject, NEVER, Observable, of, from} from 'rxjs';
+import {BehaviorSubject, NEVER, Observable, of} from 'rxjs';
 import {
   catchError,
   filter,
@@ -78,7 +78,7 @@ export class TransferStateService {
 
   constructor(@Inject(DOCUMENT) private document: Document, private router: Router) {}
 
-  startMonitoring() {
+  private startMonitoring() {
     if (window && window['ScullyIO-injected'] && window['ScullyIO-injected'].inlineStateOnly) {
       this.inlineOnly = true;
     }
@@ -167,7 +167,7 @@ export class TransferStateService {
   /**
    * starts monitoring the router, and keep the url from the last completed navigation handy.
    */
-  setupStartNavMonitoring() {
+  private setupStartNavMonitoring() {
     if (!isScullyGenerated()) {
       return;
     }
@@ -176,7 +176,14 @@ export class TransferStateService {
     this.nextUrl.subscribe();
   }
 
-  async fetchTransferState(): Promise<void> {
+  useScullyTransferState<T>(name: string, originalState: Observable<T>): Observable<T> {
+    if (isScullyGenerated()) {
+      return this.getState(name);
+    }
+    return originalState.pipe(tap(state => this.setState(name, state)));
+  }
+
+  private async fetchTransferState(): Promise<void> {
     /** helper to read the part before the first slash (ignores leading slash) */
     const base = (url: string) => url.split('/').filter(part => part.trim() !== '')[0];
     /** put this in the next event cycle so the correct route can be read */

--- a/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/projects/scullyio/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -78,7 +78,7 @@ export class TransferStateService {
 
   constructor(@Inject(DOCUMENT) private document: Document, private router: Router) {}
 
-  private startMonitoring() {
+  startMonitoring() {
     if (window && window['ScullyIO-injected'] && window['ScullyIO-injected'].inlineStateOnly) {
       this.inlineOnly = true;
     }

--- a/scully/utils/config.ts
+++ b/scully/utils/config.ts
@@ -7,6 +7,7 @@ import {logError, logWarn, yellow} from './log';
 import {validateConfig} from './validateConfig';
 import {compileConfig} from './compileConfig';
 import {readAngularJson} from './read-anguar-json';
+import {cpus} from 'os';
 export const angularRoot = findAngularJsonPath();
 export const scullyConfig: ScullyConfig = {} as ScullyConfig;
 
@@ -46,6 +47,7 @@ const loadIt = async () => {
       projectRoot: projectConfig.root,
       distFolder,
       inlineStateOnly: false,
+      maxRenderThreads: cpus().length,
       appPort: /** 1864 */ 'herodevs'.split('').reduce((sum, token) => (sum += token.charCodeAt(0)), 1000),
       staticport: /** 1668 */ 'scully'.split('').reduce((sum, token) => (sum += token.charCodeAt(0)), 1000),
       reloadPort: /** 2667 */ 'scullyLiveReload'

--- a/scully/utils/handlers/renderParallel.ts
+++ b/scully/utils/handlers/renderParallel.ts
@@ -1,8 +1,8 @@
-import {cpus} from 'os';
 import {performance} from 'perf_hooks';
 import {routeContentRenderer} from '../../renderPlugins/routeContentRenderer';
 import {writeToFs} from '../../systemPlugins/writeToFs.plugin';
 import {asyncPool} from '../asyncPool';
+import {scullyConfig} from '../config';
 import {performanceIds} from '../performanceIds';
 
 export async function renderParallel(dataRoutes) {
@@ -10,7 +10,7 @@ export async function renderParallel(dataRoutes) {
     routeContentRenderer(route).then((html: string) => writeToFs(route.route, html));
   performance.mark('startRender');
   performanceIds.add('Render');
-  const renderPool = await asyncPool(cpus().length, dataRoutes, renderRoute);
+  const renderPool = await asyncPool(scullyConfig.maxRenderThreads, dataRoutes, renderRoute);
   performance.mark('stopRender');
   return renderPool;
 }

--- a/scully/utils/interfacesandenums.ts
+++ b/scully/utils/interfacesandenums.ts
@@ -43,6 +43,8 @@ export interface ScullyConfig {
   hostUrl?: string;
   /** optional guessParserOptions, if this is provided we are going to pass those options to the guess parser. */
   guessParserOptions?: GuessParserOptions;
+  /** the maximum of concurrent puppeteer tabs open. defaults to the available amounts of cores */
+  maxRenderThreads: number;
 }
 
 interface RouteConfig {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the number of concurrent rendering threads equals node `cpus().length` (all threads on all cores)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Have a setting in scullyconfig that allows changing this to whatever value fits the app.
Also, add a utility function to the transfer state that makes it easier to incorporate using the Scully state

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
