### PR TITLE
fix(schematic): v8 support in AppModule

### DIFF
--- a/schematics/scully/src/ng-add/index.ts
+++ b/schematics/scully/src/ng-add/index.ts
@@ -51,7 +51,7 @@ const importScullyModule = (project: string) => (tree: Tree, context: SchematicC
       mainFileSource,
       mainFilePath,
       'ScullyLibModule',
-      '@scullyio/ng-lib'
+      getDependencyFileName(tree)
     ) as InsertChange;
     if (importChange.toAdd) {
       recorder.insertLeft(importChange.pos, importChange.toAdd);
@@ -111,4 +111,14 @@ const runScullySchematic = (options: Schema) => (tree: Tree, context: SchematicC
     ctx.addTask(new RunSchematicTask('run', options), [installTaskId]);
   });
   return chain(nextRules);
+};
+
+const getDependencyFileName = (tree: Tree) => {
+  const defaultDependencyFileName = '@scullyio/ng-lib';
+  const ngCoreVersionTag = getPackageVersionFromPackageJson(tree, '@angular/core');
+  if (+ngCoreVersionTag.search(/(\^8|~8)/g) === 0) {
+    return `${defaultDependencyFileName}-v8`;
+  } else {
+    return defaultDependencyFileName;
+  }
 };

--- a/schematics/scully/src/ng-add/index_spec.ts
+++ b/schematics/scully/src/ng-add/index_spec.ts
@@ -50,11 +50,6 @@ describe('ng-add schematic', () => {
       expect(appModuleContent).toMatch(/import.*zone\.js\/dist\/task-tracking/g);
     });
 
-    it('should inject the idle service into AppComponent', () => {
-      const appModuleContent = getFileContent(appTree, 'src/app/app.component.ts');
-      expect(appModuleContent).toMatch(/constructor*.*.private idle: IdleMonitorService/s);
-    });
-
     it('should run NodePackageInstallTask', () => {
       expect(schematicRunner.tasks.some(task => task.name === 'node-package')).toBe(true);
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

When using `ng add @scullyio/init` into a v8 project, the schematic checks the version to add the right dependency into the package.json file but it doesn't check it to add the right import into the AppModule file.
Resulting having :
```
// package.json
'@scullyio/ng-lib-v8'

// AppModule.ts
import { ScullyLibModule } from '@scullyio/ng-lib'
```


Issue Number: #419 

## What is the new behavior?

The schematic checks the angular version of the project for the import added into the AppModule file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The PR removes a legacy test based on #242 action