### PR TITLE
feat(scully): support for markdown options like `{:target="_blank"}`

### DIFF
--- a/blog/page-2.md
+++ b/blog/page-2.md
@@ -13,6 +13,8 @@ slugs:
 
 ## its a wild world after all
 
+Link to [angular](http://angular.io){:target=\_blank}
+
 ```typescript
 console.log('amazing');
 ```

--- a/cypress/integration/sampleBlog.spec.js
+++ b/cypress/integration/sampleBlog.spec.js
@@ -53,11 +53,16 @@ context('check first integration test', () => {
       .should('have', 'posts');
   });
 
+  it('check link to have target_blank in blog page 2', () => {
+    cy.visit('/blog/___UNPUBLISHED___k5nhcflm_SJwD4Z0QDrIHg1PGHo2mrfLZE8sfUsPy/');
+
+    cy.get('a[target]').should('have.attr', 'target', '_blank');
+  });
+
   it('Check that the slow user mock template appears then disappears', () => {
     cy.visit('/slow').reload();
 
     cy.get('app-slow>h1').contains('Scully Not Generated');
-    console.log('HERE');
     cy.wait(4100)
       .get('app-slow>h1')
       .contains('Scully Generated');

--- a/projects/scullyio/ng-lib/package.json
+++ b/projects/scullyio/ng-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/ng-lib",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "repository": {
     "type": "GIT",
     "url": "https://github.com/scullyio/scully/tree/master/projects/scullyio/ng-lib"

--- a/scully/package.json
+++ b/scully/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully",
-  "version": "0.0.81",
+  "version": "0.0.83",
   "description": "Scully CLI",
   "repository": {
     "type": "GIT",

--- a/scully/pluginManagement/systemPlugins.ts
+++ b/scully/pluginManagement/systemPlugins.ts
@@ -6,3 +6,4 @@ import '../routerPlugins/defaultRouterPlugin';
 import '../routerPlugins/ignoredRoutePlugin';
 import '../routerPlugins/jsonRoutePlugin';
 import '../renderPlugins/seoHrefCompletionPlugin';
+import '../renderPlugins/customMarkdownOptions';

--- a/scully/renderPlugins/contentRenderPlugin.ts
+++ b/scully/renderPlugins/contentRenderPlugin.ts
@@ -6,6 +6,7 @@ import {handleFile} from './content-render-utils/handleFile';
 import {insertContent} from './content-render-utils/insertContent';
 import {readFileAndCheckPrePublishSlug} from './content-render-utils/readFileAndCheckPrePublishSlug';
 import {JSDOM} from 'jsdom';
+import {customMarkdownOptions} from './customMarkdownOptions';
 
 registerPlugin('render', 'contentFolder', contentRenderPlugin);
 
@@ -24,7 +25,7 @@ export async function contentRenderPlugin(html: string, route: HandledRoute) {
         .split('>')[0]
         .trim()
     );
-    const additionalHTML = await handleFile(extension, fileContent);
+    const additionalHTML = await customMarkdownOptions(await handleFile(extension, fileContent));
     const htmlWithNgAttr = addNgIdAttribute(additionalHTML, attr);
     return insertContent(scullyBegin, scullyEnd, html, htmlWithNgAttr, getScript(attr));
   } catch (e) {

--- a/scully/renderPlugins/customMarkdownOptions.ts
+++ b/scully/renderPlugins/customMarkdownOptions.ts
@@ -1,0 +1,28 @@
+export const customMarkdownOptions = (html: string) => {
+  return html.replace(/\<a[^>]*\>[^<]*\<\/a\>\{[^}]*\}/g, (val, pos) => {
+    const [start, rest] = val.split('{:');
+    const injectStr = rest.slice(0, -1);
+    const [initial, end] = start.split('href=');
+    return `${initial} ${injectStr} href=${end}`;
+  });
+};
+
+// const test = `
+// sdfoasjdfkl sakdfjas lkdf;askdjf as;djf asldkjf
+// <a href="url">link</a>{:target="_blank" class="pepe"}
+// SOME BULLSHIT STARTING TEXT
+// <a href="bar">foo</a>{:target="_blank"}
+// BS MIDDLE TEXT
+// <a href="bar">foo</a>{:target="_blank"}
+// END TEXT
+
+// SOME BULLSHIT STARTING TEXT
+// <a href="bar">foo</a>{:target="_blank"}
+// BS MIDDLE TEXT
+// <a href="bar">foo</a>{:target="_blank"}
+// END TEXT
+// `
+
+// customMarkdownOptions(test); //?
+
+// registerPlugin('render','customMarkdownOptions', customMarkdownOptions)

--- a/scully/renderPlugins/customMarkdownOptions.ts
+++ b/scully/renderPlugins/customMarkdownOptions.ts
@@ -6,23 +6,3 @@ export const customMarkdownOptions = (html: string) => {
     return `${initial} ${injectStr} href=${end}`;
   });
 };
-
-// const test = `
-// sdfoasjdfkl sakdfjas lkdf;askdjf as;djf asldkjf
-// <a href="url">link</a>{:target="_blank" class="pepe"}
-// SOME BULLSHIT STARTING TEXT
-// <a href="bar">foo</a>{:target="_blank"}
-// BS MIDDLE TEXT
-// <a href="bar">foo</a>{:target="_blank"}
-// END TEXT
-
-// SOME BULLSHIT STARTING TEXT
-// <a href="bar">foo</a>{:target="_blank"}
-// BS MIDDLE TEXT
-// <a href="bar">foo</a>{:target="_blank"}
-// END TEXT
-// `
-
-// customMarkdownOptions(test); //?
-
-// registerPlugin('render','customMarkdownOptions', customMarkdownOptions)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
allow additional attributes to be added to target  anchors. It uses the same syntax as jekyll and kramdownL
```markdown
[someLink](http://somewhere.com){:target="_blank" class="lnk ext"}
```
 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
