### PR TITLE
fix(documentation): remove misplaced plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -315,7 +315,6 @@ module.exports.smileEmojiPlugin = smileEmojiPlugin;
 Here are some links to built-in **render plugins** in Scully:
 
 - [Route Content Renderer Plugin](../scully/renderPlugins/routeContentRenderer.ts)
-- [Content Folder Plugin](../scully/)
 
 ---
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The ContentFolder plugin (a router plugin) is included in the list of the built-in render plugins.

Issue Number: N/A

The plugin is removed from the list.
He's already inside the list of built-in router plugins

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
