### PR TITLE
docs(docsWeb): fix broken footer links

### DIFF
--- a/projects/scullyDocs/src/app/app.component.html
+++ b/projects/scullyDocs/src/app/app.component.html
@@ -26,13 +26,13 @@
 <footer>
   <div class="footer-1">
     <h3>Learn</h3>
-    <p><a routerLink="['/docs']">Docs</a></p>
-    <p><a routerLink="['/docs/getting-started']">Quickstart</a></p>
+    <p><a [routerLink]="['/docs']">Docs</a></p>
+    <p><a [routerLink]="['/docs/getting-started']">Quickstart</a></p>
     <!--p>Tutorial</p-->
   </div>
   <div class="footer-2">
     <h3>Community</h3>
-    <p><a routerLink="['/docs/CONTRIBUTING']">Contribute</a></p>
+    <p><a [routerLink]="['/docs/CONTRIBUTING']">Contribute</a></p>
     <p><a target="_blank" href="https://gitter.im/scullyio/community">Guitter Channel</a></p>
     <!--p>Upcoming Events</p-->
     <p><a target="_blank" href="https://twitter.com/scullyio">Twitter</a></p>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: minor fix on docs site

## What is the current behavior?

Links to "Docs" "Get started" and "Contributing" on the footer of scully.io site are broken.

Issue Number: N/A

## What is the new behavior?

Links to "Docs" "Get started" and "Contributing" on the footer of scully.io site are working.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
