### PR TITLE
refactor(documentation): remove duplicate mention

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,12 +9,10 @@ Welcome to Scully!
 
 Before getting started, please read the [Prerequisites](pre-requisites.md).
 
-This getting started guide covers three topics:
+This getting started guide covers two topics:
 
 1. [Installation](#installation)
 2. [Building](#build)
-
-**_IMPORTANT:_ Scully requires the router to be present in your application. To have this automatically generated, choose the option to add Angular Routing from the prompt when running the commands below.**
 
 ## Installation
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The [Getting started with Scully](https://github.com/scullyio/scully/blob/master/docs/getting-started.md) doc page warns about the required router and the option to choose to add a default routing module (with the `ng new` schematic).

With the enhancement of the docs with #383, the app generation has been moved into the [Prerequisites](https://github.com/scullyio/scully/blob/master/docs/pre-requisites.md) page and this warning is already covered with an additionnal step to generate a routing module.

I took advantage of this PR to fix the number of topics being announced in the beginning of the page, as it includes only *Installation* and *Building* now.


## What is the new behavior?

The warning information is removed.

The number of topics being announced is *two*.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No