### PR TITLE
feat(scully): new flag to set timeout for serer during CI

### DIFF
--- a/scully/utils/cli-options.ts
+++ b/scully/utils/cli-options.ts
@@ -82,7 +82,7 @@ export const {showBrowser, path, port, pjFirst, folder, sge, configFileName} = y
     'provide name of the config file to use. if the option --project is also there that takes precedence)'
   ).argv;
 
-export const {project, baseFilter, scanRoutes, hl} = yargs
+export const {project, baseFilter, scanRoutes, hl, serverTimeout} = yargs
   /** projectName */
   .string('pr')
   .alias('pr', 'project')
@@ -94,6 +94,11 @@ export const {project, baseFilter, scanRoutes, hl} = yargs
   .alias('sr', 'scanRoutes')
   .alias('sr', 'scan')
   .describe('sr', 'Scan the app for unhandled routes')
+  /** server Timout */
+  .number('st')
+  .default('st', 0)
+  .alias('st', 'serverTimeout')
+  .describe('st', 'The time Scully wait for the server before timeout. in milliseconds')
   /** package json fist */
   .boolean('pjf')
   .default('pjf', false)

--- a/scully/utils/serverstuff/waitForServerToBeAvailable.ts
+++ b/scully/utils/serverstuff/waitForServerToBeAvailable.ts
@@ -1,7 +1,9 @@
-import {ssl} from '../cli-options';
+import {ssl, serverTimeout} from '../cli-options';
 import {scullyConfig} from '../config';
 import {httpGetJson} from '../httpGetJson';
 import {logWarn} from '../log';
+
+const maxTries = serverTimeout !== 0 ? Math.ceil(serverTimeout / 125) : 80;
 /**
  * Wait until our server is up, and accepting requests
  */
@@ -11,7 +13,7 @@ export const waitForServerToBeAvailable = () =>
     const tryServer = () => {
       ++tries;
       /** 80 tries should be ~10 seconds, that should be more as enough to start the server (mostly for GA) */
-      if (tries > 80) {
+      if (tries > maxTries) {
         reject(`server didn't respond`);
       }
       httpGetJson(`http${ssl ? 's' : ''}://${scullyConfig.hostName}:${scullyConfig.appPort}/_pong`, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Now the timeout is fixed on approximately 10 seconds
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: should help #461 

## What is the new behavior?
you can set the timeout in milliseconds from the cmd line using the `--serverTimeout` flag


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
