### PR TITLE
feat(scully): add optional thumbnail to every route

### DIFF
--- a/scully.sampleBlog.config.js
+++ b/scully.sampleBlog.config.js
@@ -17,6 +17,7 @@ exports.config = {
   /** Use only inlined HTML, no data.json will be written/read */
   // inlineStateOnly: true,
   defaultPostRenderers: ['seoHrefOptimise'],
+  thumbnails: true,
   routes: {
     '/demo/:id': {
       type: 'extra',

--- a/scully/renderPlugins/puppeteerRenderPlugin.ts
+++ b/scully/renderPlugins/puppeteerRenderPlugin.ts
@@ -9,6 +9,7 @@ import {ssl} from '../utils/cli-options';
 import {scullyConfig} from '../utils/config';
 import {logError, yellow} from '../utils/log';
 import {launchedBrowser} from './launchedBrowser';
+import {createFolderFor} from '../utils';
 
 const errorredPages = new Set<string>();
 
@@ -99,6 +100,12 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
      * with the `.toString` that evalutate uses
      */
     pageHtml = await page.content();
+    /** save thumbnail to disk code */
+    if (scullyConfig.thumbnails) {
+      const file = join(scullyConfig.outDir, route.route, '/thumbnail.jpg');
+      createFolderFor(file);
+      await page.screenshot({path: file});
+    }
     // pageHtml = await page.evaluate(`(async () => {
     //   return new XMLSerializer().serializeToString(document.doctype) + document.documentElement.outerHTML
     // })()`);

--- a/scully/utils/config.ts
+++ b/scully/utils/config.ts
@@ -48,6 +48,7 @@ const loadIt = async () => {
       projectRoot: projectConfig.root,
       distFolder,
       inlineStateOnly: false,
+      tumbnails: false,
       maxRenderThreads: cpus().length,
       appPort: /** 1864 */ 'herodevs'.split('').reduce((sum, token) => (sum += token.charCodeAt(0)), 1000),
       staticport: /** 1668 */ 'scully'.split('').reduce((sum, token) => (sum += token.charCodeAt(0)), 1000),

--- a/scully/utils/interfacesandenums.ts
+++ b/scully/utils/interfacesandenums.ts
@@ -31,6 +31,8 @@ export interface ScullyConfig {
   extraRoutes?: (string | Promise<string[] | string>)[];
   /** Port-number where the original application is served */
   appPort: number;
+  /** Boolean that determines saving of site-tumbnails files */
+  thumbnails?: boolean;
   /** port-number where the Scully generated files are available */
   staticport: number;
   /** port for the live reload service */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
None
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
optionally save a thumbnail for every route. Note that this doesn't work for content(blog) routes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
