### PR TITLE
fix(docsWeb): change routerLink to link on app-button in header

### DIFF
--- a/ng-projects/scullyDocs/src/app/app.component.html
+++ b/ng-projects/scullyDocs/src/app/app.component.html
@@ -3,11 +3,11 @@
     <img src="/assets/scullyio-logo.svg" heigth="60px" width="120px" alt="scullyLogo" />
   </a>
   <nav>
-    <app-button [text]="'GET STARTED'" [class]="''" [routerLink]="'/docs'"></app-button>
-    <app-button [text]="'Features'" [class]="'btn-secondary'" [routerLink]="'/docs/features'"></app-button>
-    <app-button [text]="'Learn'" [class]="'btn-secondary'" [routerLink]="'/docs/pre-requisites'"></app-button>
-    <app-button [text]="'Docs'" [class]="'btn-secondary'" [routerLink]="'/docs/scully'"></app-button>
-    <app-button [text]="'Showcase'" [class]="'btn-secondary'" [routerLink]="'/docs/showcase'"></app-button>
+    <app-button [text]="'GET STARTED'" [class]="''" [link]="'/docs'"></app-button>
+    <app-button [text]="'Features'" [class]="'btn-secondary'" [link]="'/docs/features'"></app-button>
+    <app-button [text]="'Learn'" [class]="'btn-secondary'" [link]="'/docs/pre-requisites'"></app-button>
+    <app-button [text]="'Docs'" [class]="'btn-secondary'" [link]="'/docs/scully'"></app-button>
+    <app-button [text]="'Showcase'" [class]="'btn-secondary'" [link]="'/docs/showcase'"></app-button>
     <div class="github">
       <a href="https://github.com/scullyio/scully">
         <img


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

In the Header, the current docs site shows undefined in the path of the href. This breaks opening main menu links in a new tab.

Issue Number: N/A

## What is the new behavior?

The routerLink input is fixed to be link as expected by the app-button component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

![image](https://user-images.githubusercontent.com/1195435/79856101-bbeac800-8380-11ea-9c7b-b5dbbca17a92.png)

