### PR TITLE
fix(scully): handle `#` and `?` in urls properly

### DIFF
--- a/ng-projects/scullyio/ng-lib/src/lib/utils/basePathOnly.ts
+++ b/ng-projects/scullyio/ng-lib/src/lib/utils/basePathOnly.ts
@@ -1,0 +1,14 @@
+/**
+ * Take a string, preferably resembling an URL, take out the search params, the anchors, and the ending slash
+ * @param str
+ */
+export const basePathOnly = (str: string): string => {
+  if (str.includes('#')) {
+    str = str.split('#')[0];
+  }
+  if (str.includes('?')) {
+    str = str.split('?')[0];
+  }
+  const cleanedUpVersion = str.endsWith('/') ? str.slice(0, -1) : str;
+  return cleanedUpVersion;
+};

--- a/scully/routerPlugins/addOptionalRoutesPlugin.ts
+++ b/scully/routerPlugins/addOptionalRoutesPlugin.ts
@@ -93,6 +93,26 @@ async function routePluginHandler(route: string): Promise<HandledRoute[]> {
           )} is invalid.`
         );
       }
+      if (handledRoute.route.includes('?')) {
+        const updatedRoute = handledRoute.route.split('?')[0];
+        logWarn(
+          `The route "${yellow(
+            handledRoute.route
+          )}" contains a search param, this will be ignored during rendering. it will be truncated to:
+  "${yellow(updatedRoute)}"`
+        );
+        handledRoute.route = updatedRoute;
+      }
+      if (handledRoute.route.includes('#')) {
+        const updatedRoute = handledRoute.route.split('#')[0];
+        logWarn(
+          `The route "${yellow(
+            handledRoute.route
+          )}" contains a hash(#), this will be ignored during rendering. it will be truncated to:
+            "${yellow(updatedRoute)}"`
+        );
+        handledRoute.route = updatedRoute;
+      }
     });
     return generatedRoutes;
   }

--- a/tests/cypress/integration/sampleBlog.spec.js
+++ b/tests/cypress/integration/sampleBlog.spec.js
@@ -39,6 +39,7 @@ context('check first integration test', () => {
     cy.get('ul>li>a')
       .contains('/user')
       .click()
+      .wait(25) // give the async fetch a bit of time to complete
       .get('a')
       .contains('Leanne Graham')
       .click()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
When there is a search param `?` or a hash `#` in the URL, Scully rendered pages might fail
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Scully generated pages now ignore those parts fo the URL, as there is no way those can be stored n a file system

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
