### PR TITLE
docs(pre-requisites): change the RouterModule addition

### DIFF
--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -6,10 +6,16 @@ lang: en
 
 # Prerequisites
 
-In order to use start using Scully, you need an existing Angular application with **v8.x.x** or **v9.x.x** or You can create a new Angular 9 application by running the following command:
+In order to start using Scully, you need an existing Angular application with **v8.x.x** or **v9.x.x**.
+
+#### IMPORTANT:
+
+_Scully depends on the application's router module in order to generate the website's pages. Your application must include a RouterModule._
+
+You can create a new Angular 9 application by running the following command:
 
 ```bash
-npx -p @angular/cli ng new my-scully-app
+npx -p @angular/cli ng new my-scully-app --routing
 ```
 
 If the above command fails, install the Angular CLI globally with the following command:
@@ -21,17 +27,7 @@ npm install -g @angular/cli
 Then, create a new application.
 
 ```bash
-ng new my-scully-app
-```
-
-#### IMPORTANT:
-
-_Scully depends on the application's router module in order to generate the website's pages_
-
-Add a router module with the following command:
-
-```bash
-ng generate module app-routing --flat --module=app
+ng new my-scully-app --routing
 ```
 
 Find more info about the Angular CLI here [👉 angular.io/cli](https://angular.io/cli)

--- a/docs/pre-requisites_es.md
+++ b/docs/pre-requisites_es.md
@@ -6,10 +6,16 @@ lang: es
 
 # Requisitos previos
 
-Para comenzar a usar Scully, se necesita una aplicación Angular existente con **v8.x.x** o **v9.x.x** o puede crear una nueva aplicación Angular 9 ejecutando el siguiente comando:
+Para comenzar a usar Scully, se necesita una aplicación Angular existente con **v8.x.x** o **v9.x.x**.
+
+#### IMPORTANTE:
+
+_Scully depende del módulo de rutas de la aplicación para generar las páginas del sitio web_
+
+Puede crear una nueva aplicación Angular 9 ejecutando el siguiente comando:
 
 ```bash
-npx -p @angular/cli ng new my-scully-app
+npx -p @angular/cli ng new my-scully-app --routing
 ```
 
 Si el comando anterior falla, instale el Angular CLI globalmente con el siguiente comando:
@@ -21,17 +27,7 @@ npm install -g @angular/cli
 Luego, crea una nueva aplicación.
 
 ```bash
-ng new my-scully-app
-```
-
-#### IMPORTANTE:
-
-_Scully depende del módulo de rutas de la aplicación para generar las páginas del sitio web_
-
-Agregue un módulo de rutas con el siguiente comando:
-
-```bash
-ng generate module app-routing --flat --module=app
+ng new my-scully-app --routing
 ```
 
 Encuentre más información sobre el Angular CLI aquí [👉 angular.io/cli](https://angular.io/cli)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: doc update

## What is the current behavior?

The schematic listed into the documentation `ng generate module app-routing --flat --module=app` adds a module without **RouterModule**

## What is the new behavior?

- move up the warning about RouterModule pre-requisite
- remove the schematic command adding a routing module
- add --routing to the existing creation commands

Close #534 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No