### PR TITLE
fix(scully): typo loaed -> loaded

### DIFF
--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -36,7 +36,7 @@ if (process.argv.includes('version')) {
   /** make sure not to do something before the config is ready */
   console.log('going to load');
   const scullyConfig = await loadConfig;
-  console.log('config loaed');
+  console.log('config loaded');
   if (cliOption.hostName) {
     scullyConfig.hostName = cliOption.hostName;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- fixes a typo in the CLI output
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
```sh
> scully serve

starting
going to load
config loaed
before build
starting static server
```
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
```sh
> scully serve

starting
going to load
config loaded
before build
starting static server
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
