### PR TITLE
fix(scully): fix defaultPostRenderers type

### DIFF
--- a/docs/scully-configuration.md
+++ b/docs/scully-configuration.md
@@ -37,32 +37,36 @@ The `scully.<projectname>.config.ts` file's structure is shown below:
 
 ```ts
 export interface ScullyConfig {
+  /** is this a bare project (without angular.json?) */
+  bareProject?: boolean;
   /** the name of the project we are using. Provided by Scully itself */
-  projectName: string;
+  projectName?: string;
   /** the folder where project is. Can be any off the projects in a repo, read from angular.json */
   projectRoot?: string;
   /** the folder where the project sources resides, read from angular.json */
   sourceRoot?: string;
-  /** Array with string ID's of the content-renders that will be run on all routes */
-  defaultPostRenderers: string[];
+  /** Array with string ID's of the content-renderers that will be run on all routes */
+  defaultPostRenderers?: string[];
   /** the root of the project (where angular.json lives) */
-  homeFolder: string;
+  homeFolder?: string;
   /** the destination of the Scully generated files */
   outDir?: string;
   /** the place where distribution files of the project are. Should be a subfolder of dist. */
   distFolder?: string;
   /** transferState only inlined into page, and not written into separate data.json */
-  inlineStateOnly: boolean;
+  inlineStateOnly?: boolean;
   /** routes that need additional processing have their configuration in here */
   routes: RouteConfig;
   /** routes that are in the application but have no route in the router */
-  extraRoutes?: (string | Promise<string[] | string>)[];
+  extraRoutes?: string | string[] | Promise<string[] | string>;
   /** Port-number where the original application is served */
-  appPort: number;
+  appPort?: number;
+  /** Boolean that determines saving of site-tumbnails files */
+  thumbnails?: boolean;
   /** port-number where the Scully generated files are available */
-  staticport: number;
+  staticport?: number;
   /** port for the live reload service */
-  reloadPort: number;
+  reloadPort?: number;
   /** optional proxy config file, uses the same config file as the CLI */
   proxyConfig?: string;
   /** optional launch-options for puppeteer */
@@ -74,7 +78,7 @@ export interface ScullyConfig {
   /** optional guessParserOptions, if this is provided we are going to pass those options to the guess parser. */
   guessParserOptions?: GuessParserOptions;
   /** the maximum of concurrent puppeteer tabs open. defaults to the available amounts of cores */
-  maxRenderThreads: number;
+  maxRenderThreads?: number;
 }
 ```
 
@@ -141,7 +145,11 @@ Eg.
 It can handle `string`, `string[]`, `Promise<string>` or `Promise<string[]>`
 
 ```typescript
-extraRoutes: ['/foo/:id', new Promise('/bar/:barId'), new Promise(['/foo/:fooId', '/bar/:id'])];
+extraRoutes: [
+  '/foo/:id',
+  new Promise('/bar/:barId'),
+  new Promise(['/foo/:fooId', '/bar/:id'])
+];
 ```
 
 ### appPort

--- a/libs/scully/src/lib/utils/interfacesandenums.ts
+++ b/libs/scully/src/lib/utils/interfacesandenums.ts
@@ -16,7 +16,7 @@ export interface ScullyConfig {
   /** the folder where the project sources resides, read from angular.json */
   sourceRoot?: string;
   /** Array with string ID's of the content-renderes that will be run on all routes */
-  defaultPostRenderers: string[];
+  defaultPostRenderers?: string[];
   /** the root of the project (where angular.json lives) */
   homeFolder?: string;
   /** the destination off the Scully generated files */

--- a/libs/scully/src/lib/utils/interfacesandenums.ts
+++ b/libs/scully/src/lib/utils/interfacesandenums.ts
@@ -15,17 +15,17 @@ export interface ScullyConfig {
   projectRoot?: string;
   /** the folder where the project sources resides, read from angular.json */
   sourceRoot?: string;
-  /** Array with string ID's of the content-renderes that will be run on all routes */
+  /** Array with string ID's of the content-renderers that will be run on all routes */
   defaultPostRenderers?: string[];
   /** the root of the project (where angular.json lives) */
   homeFolder?: string;
-  /** the destination off the Scully generated files */
+  /** the destination of the Scully generated files */
   outDir?: string;
   /** the place where distribution files of the project are. Should be a subfolder of dist. */
   distFolder?: string;
   /** transferState only inlined into page, and not written into separate data.json */
   inlineStateOnly?: boolean;
-  /** routes that needs additional processing have their configuration in here */
+  /** routes that need additional processing have their configuration in here */
   routes: RouteConfig;
   /** routes that are in the application but have no route in the router */
   extraRoutes?: string | string[] | Promise<string[] | string>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
No, but I think tests for types are not needed in this time.
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Linter says "`defaultPostRenderers` is missing" which is an optional array.
https://github.com/scullyio/scully/blob/master/libs/scully/src/lib/utils/config.ts#L74

![image](https://user-images.githubusercontent.com/2607019/82136901-be402500-984d-11ea-88ea-740d30d68b16.png)

## What is the new behavior?
There should be no errors after the config file is generated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The document for the interface is synchronized to the latest `ScullyConfig`. 
