### PR TITLE
docs: ✏️ add more descriptive examples to getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,13 +82,13 @@ const routes: Routes = [
 Scully provides a service for accessing generated routes with ease. To use it, open the `home.component.ts` file and add the following code:
 
 ```ts
-import {ScullyRoutesService} from '@scullyio/ng-lib';
+import {ScullyRoutesService, ScullyRoute} from '@scullyio/ng-lib';
 import {Observable} from 'rxjs';
 
 @Component()
 //...
 export class HomeComponent implements OnInit {
-  links$: Observable<any> = this.scully.available$;
+  links$: Observable<ScullyRoute[]> = this.scully.available$;
 
   constructor(private scully: ScullyRoutesService) {}
 
@@ -101,7 +101,22 @@ export class HomeComponent implements OnInit {
 }
 ```
 
-Now, it is possible to loop through the links inside the template by opening the `home.component.html` file and adding the following code:
+We can see `ScullyRoutesService.available$` returns an Observable of an array of `ScullyRoute`s, the interface of which looks like this:
+
+```ts
+export interface ScullyRoute {
+  route: string;
+  title?: string;
+  slugs?: string[];
+  published?: boolean;
+  slug?: string;
+  sourceFile?: string;
+  [prop: string]: any;
+}
+```
+
+To extract data from the available `links$` Scully has rendered, we can loop through them inside the template by opening the `home.component.html` file and adding the following code:
+
 
 ```html
 <p>home works!</p>
@@ -112,6 +127,34 @@ Now, it is possible to loop through the links inside the template by opening the
 ```
 
 **NOTE:** If you don't add any route, scully will pre-render 0 pages.
+
+### Adding metadata to `ScullyRoutes`
+
+At the very top of each `.md` blog post file, between the opening and closing `---` indicators, each line of text corresponds to a property we can pull out of `ScullyRoutesService.available$`.
+
+For example, a `.md` file beginning with:
+```
+---
+title: blog title
+description: blog description
+published: true
+arbitraryValue: single value
+arbitraryArray: [first item, second item]
+---
+```
+
+... lets us use these values in our template like this:
+```html
+<ul>
+  <li *ngFor="let page of links$ | async">
+    {{ page.route }}
+    {{ page.arbitraryValue }}
+    <span *ngFor="let arrayItem of page.arbitraryArray">
+      {{ arrayItem }}
+    </span>
+  </li>
+</ul>
+```
 
 ## Build
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: Adds more descriptive examples to Getting Started docs.

## What is the current behavior?

Issue Number: #501 
The current Getting Started docs are a bit vague on where Scully gets the data for `ScullyRouteService.available$` and how to add additional values to that data.

## What is the new behavior?

`getting-started.md` now references the `ScullyRoute` interface, explains how its shape corresponds to `.md` blog post metadata, and how to include these additional arbitrary values in a template.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
