### PR TITLE
Feature to ignore specific ResourceTypes in Puppeteer

### DIFF
--- a/docs/scully-configuration.md
+++ b/docs/scully-configuration.md
@@ -79,6 +79,8 @@ export interface ScullyConfig {
   guessParserOptions?: GuessParserOptions;
   /** the maximum of concurrent puppeteer tabs open. defaults to the available amounts of cores */
   maxRenderThreads?: number;
+  /** the resource types to ignore when generating pages via Puppeteer */
+  ignoreResourceTypes?: ResourceType[];
 }
 ```
 
@@ -198,3 +200,9 @@ Connects your application to a different host. This is useful when using your ow
 
 The`guessParserOptions` that get passed to the `guess-parser` library. Currently, the only supported property is
 `excludedFiles`, and it excludes files from the `guess-parser` route discovery process.
+
+### ignoreResourceTypes
+
+The `ignoreResourceTypes` array that get passed to the `puppeteerRenderPlugin`.
+Any `ResourceType` that is listed here will be ignored by the Puppeteer instance rendering the requested page.
+For example if you add `image` and `font` all requests to images and fonts loaded on your pages will be ignored.

--- a/libs/scully/src/lib/renderPlugins/puppeteerRenderPlugin.ts
+++ b/libs/scully/src/lib/renderPlugins/puppeteerRenderPlugin.ts
@@ -53,11 +53,13 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
       page.on('requestfailed', unRegisterRequest);
 
       const requests = new Set();
+
       // eslint-disable-next-line no-inner-declarations
       function registerRequest(request) {
         request.continue();
         requests.add(requests);
       }
+
       // eslint-disable-next-line no-inner-declarations
       function unRegisterRequest(request) {
         // request.continue();
@@ -78,6 +80,24 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
           }
         });
     }
+
+    if (
+      scullyConfig.ignoreResourceTypes &&
+      scullyConfig.ignoreResourceTypes.length > 0
+    ) {
+      await page.setRequestInterception(true);
+      page.on('request', checkIfRequestShouldBeIgnored);
+
+      // eslint-disable-next-line no-inner-declarations
+      function checkIfRequestShouldBeIgnored(request) {
+        if (scullyConfig.ignoreResourceTypes.includes(request.resourceType())) {
+          request.abort();
+        } else {
+          request.continue();
+        }
+      }
+    }
+
     /** this will be called from the browser, but runs in node */
     await page.exposeFunction('onCustomEvent', () => {
       resolve();

--- a/libs/scully/src/lib/utils/interfacesandenums.ts
+++ b/libs/scully/src/lib/utils/interfacesandenums.ts
@@ -1,4 +1,4 @@
-import { LaunchOptions } from 'puppeteer';
+import { LaunchOptions, ResourceType } from 'puppeteer';
 
 export enum RouteTypes {
   json = 'json',
@@ -49,6 +49,8 @@ export interface ScullyConfig {
   guessParserOptions?: GuessParserOptions;
   /** the maximum of concurrent puppeteer tabs open. defaults to the available amounts of cores */
   maxRenderThreads?: number;
+  /** the resource types to ignore when generating pages via Puppeteer */
+  ignoreResourceTypes?: ResourceType[];
 }
 
 interface RouteConfig {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

All images / fonts / stylesheets are currently also loaded in Puppeteer when requesting a page. In most cases they are not relevant for prerendering the HTML.

## What is the new behavior?

Any `ResourceType` that is listed here will be ignored by the Puppeteer instance rendering the requested page. For example if you add `image` and `fonts` all requests to images and fonts loaded on your pages will be blocked.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (it's opt-in)
## Other information
