### PR TITLE
Add `rel="noreferrer noopener"` to anchors with `target="_blank"`

### DIFF
--- a/apps/sample-blog/src/app/about/about.component.html
+++ b/apps/sample-blog/src/app/about/about.component.html
@@ -1,1 +1,3 @@
 <p>about works!</p>
+
+<a href="https://scully.io" target="_blank">Scully docs site</a>

--- a/libs/scully/src/lib/renderPlugins/seoHrefCompletionPlugin.ts
+++ b/libs/scully/src/lib/renderPlugins/seoHrefCompletionPlugin.ts
@@ -15,6 +15,16 @@ const seoHrefPlugin = async (
     const anchors = window.document.querySelectorAll('[href]');
     anchors.forEach(a => {
       const href = a.getAttribute('href');
+      /** Add noopener and noreferrer to _blank links */
+      if (href && a.getAttribute('target') === '_blank') {
+        /** get the attribute add the options and filter out duplicates */
+        const rel = ((a.getAttribute('rel') || '') + ' noreferrer noopener')
+          .trim()
+          .split(' ')
+          .filter((v, i, a) => a.indexOf(v) === i)
+          .join(' ');
+        a.setAttribute('rel', rel);
+      }
       if (
         routes.find(route => route.route === href) === undefined ||
         href.endsWith('/')
@@ -27,6 +37,7 @@ const seoHrefPlugin = async (
     });
     return dom.serialize();
   } catch (e) {
+    console.log(e);
     logWarn(
       `Error in the seoHrefOptimise plugin, didn't update href's for route: "${yellow(
         route.route

--- a/tests/jest/src/__tests__/seoOptimize.spec.ts
+++ b/tests/jest/src/__tests__/seoOptimize.spec.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { replaceIndexNG } from '../test-config.helper';
+// import { JSDOM } from 'jsdom';
+
+describe('check work of SEO-optimize plugin', () => {
+  /** use jsDom to extract all links from html */
+  const index: string = readFileSync(
+    join(__dirname, '../../../../dist/static/about/index.html'),
+    'UTF8'
+  ).toString();
+  /** you cant seem to se innerHTML on document directly in here. */
+  document.body.parentElement.innerHTML = index;
+  const anchors = Array.from(window.document.querySelectorAll('[href]'));
+
+  it('there should be noRef and noOpen on external links', () => {
+    const ext = anchors.find(a => a.getAttribute('target') === '_blank');
+    expect(ext.getAttribute('rel')).toMatch('noreferrer noopener');
+  });
+
+  it('the home link should end with //', () => {
+    const int = anchors.find(a => a.getAttribute('href') === '/home/');
+    expect(int.getAttribute('href')).toMatch('/home/');
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
none.

Issue Number: N/A

## What is the new behavior?
All link that have `target="_blank"` get the attribute `rel="noreferrer noopener"` added to enhance security and SEO score

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
