### PR TITLE
docs(lib-core): add more information about enabling manualIdle

### DIFF
--- a/docs/scully-lib-core.md
+++ b/docs/scully-lib-core.md
@@ -19,6 +19,58 @@ This section covers Scully's core features, and they are listed below:
 The `IdleMonitorService` hooks into Zonejs. When Angular goes idle (**more precisely, when all outgoing HTTP requests finish**)
 Scully triggers Puppeteer in order to know when it is ready to render. This service is in the `ScullyLibModule`.
 
+If your content is loaded out of sight of zones, Scully scrapes the page before its ready.
+
+To disable Scully ready mechanism and add your custom mechanism
+
+- Put following config object in the forRoot config
+
+```typescript
+ScullyLibModule.forRoot({
+  useTransferState: true,
+  alwaysMonitor: false,
+  manualIdle: true
+});
+```
+
+This will cause Scully to fall-back to using a 25 seconds timeout, on every page rendered.
+
+- Then in your component, trigger the fireManualMyAppReadyEvent().
+
+```typescript
+export class ManualIdleComponent implements OnInit {
+  text = 'this text is displayed by automated detection';
+
+  constructor(private ims: IdleMonitorService) {}
+
+  ngOnInit(): void {
+    setTimeout(() => (this.text = '__ManualIdle__'), 3 * 1000);
+    setTimeout(() => this.ims.fireManualMyAppReadyEvent(), 3.25 * 1000);
+  }
+}
+```
+
+- To enable this for single route, provide "manualIdle:true" inside the config.ts file in the route configuration.
+
+```typescript
+// scully.config.ts
+export const config: ScullyConfig = {
+  routes: {
+    '/user/:userId': {
+      type: 'json',
+      // Add the following to your route
+      exposeToPage:{
+        manualIdle: true
+      }
+      userId: {
+        url: 'http://localhost:8200/users',
+        property: 'id'
+      }
+    }
+  }
+};
+```
+
 ## Router Service
 
 The `ScullyRoutesService` provides methods and observables that allow you to know the routes rendered by Scully.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: docs

## What is the current behavior?

There is no information present about how to disable scully ready mechanism and add custom one
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Added information about the manualIdle flag and how to trigger the app ready event manually.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
