### PR TITLE
feat(scully): add an cli option that allows you to filter routes

### DIFF
--- a/libs/scully/src/lib/pluginManagement/pluginRepository.ts
+++ b/libs/scully/src/lib/pluginManagement/pluginRepository.ts
@@ -30,7 +30,7 @@ export const plugins: Plugins = {
   router: {},
   fileHandler: {},
   routeDiscoveryDone: {},
-  allDone: {}
+  allDone: {},
 };
 
 export type PluginTypes = keyof Plugins;
@@ -39,16 +39,17 @@ export const pluginTypes = [
   'render',
   'fileHandler',
   'allDone',
-  'routeDiscoveryDone'
+  'routeDiscoveryDone',
 ] as const;
 
+// eslint-disable @typescript-eslint/no-explicit-any
 export const registerPlugin = (
   type: PluginTypes,
   name: string,
   plugin: any,
   pluginOptions: any = async (config?: any) => [],
   { replaceExistingPlugin = false } = {}
-) => {
+): void => {
   if (!pluginTypes.includes(type)) {
     throw new Error(`
 --------------
@@ -69,7 +70,9 @@ export const registerPlugin = (
 ---------------
    Route plugin "${yellow(
      name
-   )}" should have an config validator attached to '${plugin.name}'
+   )}" validator needs to be of type function not "${yellow(
+        typeof pluginOptions
+      )}"'
 ---------------
 `);
       pluginOptions = async () => [];

--- a/libs/scully/src/lib/utils/cli-options.ts
+++ b/libs/scully/src/lib/utils/cli-options.ts
@@ -9,7 +9,7 @@ export const {
   sslKey,
   tds,
   proxyConfigFile,
-  hostName
+  hostName,
 } =
   /** return the argv */
   yargs
@@ -91,11 +91,11 @@ export const {
   configFileName,
   project,
   baseFilter,
+  routeFilter,
   scanRoutes,
   pjFirst,
-  hl,
   serverTimeout,
-  pluginsError
+  pluginsError,
 } = yargs
   /** config file  */
   .string('cf')
@@ -135,12 +135,18 @@ export const {
   .string('bf')
   .alias('bf', 'baseFilter')
   .default('bf', '')
-  .describe('bf', 'provide a minimatch glob for the unhandled routes')
-  /** highlight.js */
-  .string('hl')
-  .alias('hl', 'highlight')
-  .default('hl', false)
-  .describe('hl', 'provide a minimatch glob for the unhandled routes')
+  .describe(
+    'bf',
+    'provide a wildcard string separated by ,(comma) to filter the unhandled routes'
+  )
+  /** filter */
+  .string('routeFilter')
+  .alias('routeFilter', 'rf')
+  .default('routeFilter', '')
+  .describe(
+    'routeFilter',
+    'provide a wildcard string separated by ,(comma) to filter the handled routes'
+  )
   /** Exit Scully with plugin error */
   .boolean('pe')
   .alias('pe', 'pluginsError')
@@ -149,7 +155,7 @@ export const {
 
 yargs.help();
 
-const commandsArray = yargs.argv._.map(c => c.toLowerCase().trim());
+const commandsArray = yargs.argv._.map((c) => c.toLowerCase().trim());
 
 export const serve = commandsArray.includes('serve');
 export const killServer = commandsArray.includes('killserver');
@@ -157,5 +163,5 @@ export const killServer = commandsArray.includes('killserver');
 export const { argv: options } = yargs.option('port', {
   alias: 'p',
   type: 'number',
-  description: 'The port to run on'
+  description: 'The port to run on',
 });

--- a/libs/scully/src/lib/utils/handlers/routeDiscovery.ts
+++ b/libs/scully/src/lib/utils/handlers/routeDiscovery.ts
@@ -1,38 +1,65 @@
 import { performance } from 'perf_hooks';
 import {
   addOptionalRoutes,
-  HandledRoute
+  HandledRoute,
 } from '../../routerPlugins/addOptionalRoutesPlugin';
 import { storeRoutes } from '../../systemPlugins/storeRoutes';
 import { log, logError } from '../log';
 import { performanceIds } from '../performanceIds';
+import { routeFilter } from '../cli-options';
 
 export async function routeDiscovery(
   unhandledRoutes: string[],
   localBaseFilter: string
-) {
+): Promise<HandledRoute[]> {
   performance.mark('startDiscovery');
   performanceIds.add('Discovery');
   log('Pull in data to create additional routes.');
   let handledRoutes = [] as HandledRoute[];
+  /** baseroutes are always the start of the route, so it ends with an trailing `*` */
+  const baseFilterRegexs = wildCardStringToRegEx(localBaseFilter, {
+    addTrailingStar: true,
+  });
+  const routeFilterRegexs = wildCardStringToRegEx(routeFilter);
   try {
     handledRoutes = (
       await addOptionalRoutes(
         /** use all handled routes without empty ones, and apply the baseFilter */
         unhandledRoutes.filter(
-          (r: string) => typeof r === 'string' && r.startsWith(localBaseFilter)
+          (r: string) =>
+            typeof r === 'string' &&
+            baseFilterRegexs.some((reg) => r.match(reg) !== null)
         )
       )
-    ).filter(r => !r.route.endsWith('*'));
+    ).filter(
+      (r) =>
+        !r.route.endsWith('*') &&
+        (routeFilter === '' ||
+          routeFilterRegexs.some((reg) => r.route.match(reg) !== null))
+    );
   } catch (e) {
     logError(`Problem during route handling, see below for details`);
     console.error(e);
   }
   performance.mark('stopDiscovery');
   /** save routerinfo, so its available during rendering */
-  if (localBaseFilter === '') {
+  if (localBaseFilter === '' && routeFilter === '') {
     /** only store when the routes are complete  */
     await storeRoutes(handledRoutes);
   }
   return handledRoutes;
+}
+
+function wildCardStringToRegEx(
+  string,
+  { addTrailingStar } = { addTrailingStar: false }
+) {
+  const t = string.split(',');
+  return t.map((item) => {
+    if (addTrailingStar) {
+      item += '*';
+    }
+    const escaped = item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+    return new RegExp(`^${escaped.replace(/\\\*/g, '.*?')}$`, 'gi');
+  });
 }

--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -39,15 +39,15 @@ if (process.argv.includes('version')) {
     await httpGetJson(
       `http://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`,
       {
-        suppressErrors: true
+        suppressErrors: true,
       }
-    ).catch(e => e);
+    ).catch((e) => e);
     await httpGetJson(
       `https://${scullyConfig.hostName}:${scullyConfig.appPort}/killMe`,
       {
-        suppressErrors: true
+        suppressErrors: true,
       }
-    ).catch(e => e);
+    ).catch((e) => e);
     logWarn('Sent kill command to server');
     process.exit(0);
     return;
@@ -68,7 +68,7 @@ if (process.argv.includes('version')) {
     /** copy in current build artifacts */
     await moveDistAngular(folder, scullyConfig.outDir, {
       removeStaticDist: cliOption.removeStaticDist,
-      reset: false
+      reset: false,
     });
     const isTaken = await isPortTaken(scullyConfig.staticport);
 
@@ -84,7 +84,7 @@ You are using "${yellow(scullyConfig.hostUrl)}" as server.
         // debug only
         console.log(`Background servers already running.`);
       }
-      if (!(await waitForServerToBeAvailable().catch(e => false))) {
+      if (!(await waitForServerToBeAvailable().catch((e) => false))) {
         logError('Could not connect to server');
         process.exit(15);
       }
@@ -111,7 +111,7 @@ You are using "${yellow(scullyConfig.hostUrl)}" as server.
             scullyConfig.appPort
           }/killMe`,
           {
-            suppressErrors: true
+            suppressErrors: true,
           }
         );
       }

--- a/libs/scully/tsconfig.lib.json
+++ b/libs/scully/tsconfig.lib.json
@@ -16,9 +16,10 @@
     "sourceMap": true,
     "target": "es2018",
     "types": ["node"],
-    "typeRoots": []
+    "typeRoots": [],
+    "allowSyntheticDefaultImports": true
   },
-  "files": ["./src/index.ts", "src/scully.ts"],
+  "files": ["src/index.ts", "src/scully.ts"],
   "exclude": [
     "src/bin/**/*",
     "src/bin/**/*.d.ts",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
none
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
added an `--routeFilter` CLI option that takes a string that allows wildcards, and uses this to match routes. It only works when an unfiltered run is done at least once.
The string has can be `,`(comma) separated. 
As an example,
```bash
npm run scully --project sampleBlog  --rf="*de*/2,/user/2*/18"
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
