### PR TITLE
fix(lib): make sure routes that are not duplicates are not filtered out of `available$`

### DIFF
--- a/libs/ng-lib/src/lib/route-service/scully-routes.service.ts
+++ b/libs/ng-lib/src/lib/route-service/scully-routes.service.ts
@@ -5,7 +5,7 @@ import {
   map,
   shareReplay,
   switchMap,
-  filter
+  filter,
 } from 'rxjs/operators';
 import { fetchHttp } from '../utils/fetchHttp';
 import { Router, NavigationEnd, NavigationStart } from '@angular/router';
@@ -23,7 +23,7 @@ export interface ScullyRoute {
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ScullyRoutesService {
   private refresh = new ReplaySubject<void>(1);
@@ -39,7 +39,7 @@ export class ScullyRoutesService {
       return of([] as ScullyRoute[]);
     }),
     /** filter out all non-array results */
-    filter(routes => Array.isArray(routes)),
+    filter((routes) => Array.isArray(routes)),
     map(this.cleanDups),
     shareReplay({ refCount: false, bufferSize: 1 })
   );
@@ -47,8 +47,8 @@ export class ScullyRoutesService {
    * An observable with available routes (all published routes)
    */
   available$ = this.allRoutes$.pipe(
-    map(list =>
-      list.filter(r =>
+    map((list) =>
+      list.filter((r) =>
         r.hasOwnProperty('published') ? r.published !== false : true
       )
     ),
@@ -59,8 +59,8 @@ export class ScullyRoutesService {
    * an observable with all unpublished routes
    */
   unPublished$ = this.allRoutes$.pipe(
-    map(list =>
-      list.filter(r =>
+    map((list) =>
+      list.filter((r) =>
         r.hasOwnProperty('published') ? r.published === false : false
       )
     ),
@@ -72,7 +72,7 @@ export class ScullyRoutesService {
    * (in an urls it would be `http://www.sample.org/__thisPart__/subroutes`)
    */
   topLevel$: Observable<ScullyRoute[]> = this.available$.pipe(
-    map(routes =>
+    map((routes) =>
       routes.filter((r: ScullyRoute) => !r.route.slice(1).includes('/'))
     ),
     shareReplay({ refCount: false, bufferSize: 1 })
@@ -94,16 +94,16 @@ export class ScullyRoutesService {
     }
     /** fire off at start, and when navigation is done. */
     return merge(of(new NavigationEnd(0, '', '')), this.router.events).pipe(
-      filter(e => e instanceof NavigationEnd),
+      filter((e) => e instanceof NavigationEnd),
       switchMap(() => this.available$),
-      map(list => {
+      map((list) => {
         const curLocation = basePathOnly(encodeURI(location.pathname).trim());
         return list.find(
-          r =>
+          (r) =>
             curLocation === basePathOnly(r.route.trim()) ||
             (r.slugs &&
               Array.isArray(r.slugs) &&
-              r.slugs.find(slug =>
+              r.slugs.find((slug) =>
                 curLocation.endsWith(basePathOnly(slug.trim()))
               ))
         );
@@ -117,7 +117,10 @@ export class ScullyRoutesService {
    */
   private cleanDups(routes: ScullyRoute[]) {
     const m = new Map<string, ScullyRoute>();
-    routes.forEach(r => m.set(r.sourceFile || r.route, r));
+    /** check for duplicates by comparing all, include route in comparison if its the only thing, or the only thing with only the tile  */
+    routes.forEach((r) =>
+      m.set(JSON.stringify({ ...r, route: hasOtherprops(r) ? '' : r.route }), r)
+    );
     return [...m.values()];
   }
 
@@ -125,4 +128,15 @@ export class ScullyRoutesService {
   reload(): void {
     this.refresh.next();
   }
+}
+
+function hasOtherprops(obj) {
+  const keys = Object.keys(obj);
+  if (keys.length === 1 && keys.includes('route')) {
+    return false;
+  }
+  if (keys.length === 2 && keys.includes('route') && keys.includes('title')) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
If there are 2 routes with the same filname  but from different contentfolder, one of them gets removed.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #662

## What is the new behavior?
Only remove duplicates if they are really a duplicate (everything the same but the route, but if it's just a route, use the route)

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
