### PR TITLE
fix(monorepo): fix base-href-plugin to actually use existing scully, and not to bring it its won cop

### DIFF
--- a/libs/plugins/base-href-rewrite/package.json
+++ b/libs/plugins/base-href-rewrite/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/scullyio/scully/tree/main/libs/plugins/base-href-rewrite"
   },
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.13.0"
+  "peerDependencies": {
+    "@scullyio/scully": "*"
   }
 }

--- a/libs/plugins/base-href-rewrite/package.json
+++ b/libs/plugins/base-href-rewrite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully-plugin-base-href-rewrite",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "index.js",
   "author": "Sander Elias",
   "repository": {

--- a/libs/plugins/base-href-rewrite/src/lib/plugins-base-href-rewrite.ts
+++ b/libs/plugins/base-href-rewrite/src/lib/plugins-base-href-rewrite.ts
@@ -4,10 +4,10 @@ import {
   setMyConfig,
   getMyConfig,
   log,
-  yellow
+  yellow,
 } from '@scullyio/scully';
 
-export const baseHrefRewrite = 'baseHrefRewrite';
+export const baseHrefRewrite = Symbol('baseHrefRewrite');
 
 const baseHrefRewritePlugin = async (
   html: string,
@@ -38,7 +38,7 @@ const baseHrefRewritePlugin = async (
 };
 
 setMyConfig(baseHrefRewritePlugin, {
-  href: '/'
+  href: '/',
 });
 
-registerPlugin('render', 'baseHrefRewrite', baseHrefRewritePlugin);
+registerPlugin('render', baseHrefRewrite, baseHrefRewritePlugin);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
the plugin doesn't work outside our monorepo
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #706

## What is the new behavior?
The plugin does work, by making sure it lists Scully as a peer dep, and not as a dep. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
