### PR TITLE
docs(faq): unexpected character

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -60,7 +60,8 @@ It takes the `preLangConfig` and iterates over all the routes. When it finds the
 
 <details>
 <summary>Ignore routes without config?</summary>
-> In my app I have a lot of routes I don't want scully to handle.  How can I deal with that.
+
+> In my app I have a lot of routes I don't want scully to handle. How can I deal with that.
 
 Scully will use the `default` plugin for any route that is not specified. When you want to have another way to handle defaults, you can replace this plugin with another one.
 For example, if you want to ignore all undefined routes you can do:

--- a/tests/jest/src/__tests__/__snapshots__/docsThere.spec.ts.snap
+++ b/tests/jest/src/__tests__/__snapshots__/docsThere.spec.ts.snap
@@ -580,8 +580,10 @@ an endpoint dedicated.<br =\\"\\"> How can I solve this?</p>
 
 <details =\\"\\">
 <summary =\\"\\">Ignore routes without config?</summary>
-&gt; In my app I have a lot of routes I don't want scully to handle.  How can I deal with that.
 
+<blockquote =\\"\\">
+<p =\\"\\">In my app I have a lot of routes I don't want scully to handle. How can I deal with that.</p>
+</blockquote>
 <p =\\"\\">Scully will use the <code =\\"\\">default</code> plugin for any route that is not specified. When you want to have another way to handle defaults, you can replace this plugin with another one.
 For example, if you want to ignore all undefined routes you can do:</p>
 <pre =\\"\\"><code class=\\"language-typescript\\" =\\"\\">registerPlugin(<span class=\\"hljs-string\\" =\\"\\">'router'</span>, <span class=\\"hljs-string\\" =\\"\\">'default'</span>, findPlugin(<span class=\\"hljs-string\\" =\\"\\">'ignored'</span>));</code></pre>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: doc

## What is the current behavior?

There is an unexpected character in front of the first line of *Ignore routes without config?* FAQ (https://scully.io/docs/faq/)

Issue Number: #720 

## What is the new behavior?

There is a blank line before this line in order to detect the **>** character to render a blockquote tag

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
