### PR TITLE
fix(lib): remove scroll event after angular load in flash prevention

### DIFF
--- a/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
+++ b/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
@@ -56,26 +56,17 @@ async function createSecondAppRoot(html) {
   const [openTagMatch] = html.match(appRootStartRegExp);
   const [closeTagMatch] = html.match(appRootEndRegExp);
 
-  const cleanedAppRootOpenTag: string = fetchCleanedOpenTag(
-    openTagMatch,
-    AppRootAttrsBlacklist
+  const cleanedAppRootOpenTag: string = fetchCleanedOpenTag(openTagMatch, AppRootAttrsBlacklist);
+  const cleanedMockOpenTag: string = fetchCleanedOpenTag(openTagMatch, MockRootAttrsBlacklist).replace(
+    appRootSelector,
+    `${appRootSelector}-scully`
   );
-  const cleanedMockOpenTag: string = fetchCleanedOpenTag(
-    openTagMatch,
-    MockRootAttrsBlacklist
-  ).replace(appRootSelector, `${appRootSelector}-scully`);
 
   const newHtml = html
     // replace the closing tag with replacement scully closing tag
-    .replace(
-      closeTagMatch,
-      `${closeTagMatch.replace(appRootSelector, `${appRootSelector}-scully`)}`
-    )
+    .replace(closeTagMatch, `${closeTagMatch.replace(appRootSelector, `${appRootSelector}-scully`)}`)
     // replace opening tag with cleaned app root tag AND replacement scully app root tag
-    .replace(
-      openTagMatch,
-      `${cleanedAppRootOpenTag}${closeTagMatch}${cleanedMockOpenTag}`
-    );
+    .replace(openTagMatch, `${cleanedAppRootOpenTag}${closeTagMatch}${cleanedMockOpenTag}`);
   ``;
   return newHtml;
 }
@@ -88,18 +79,20 @@ async function addBitsToHead(html) {
 	  	document.documentElement.scrollTop = window['ScullyIO-scrollPosition'];
 	  }
 	  window['ScullyIO-scrollPosition'] = document.documentElement.scrollTop;
-	  function detach() {
-		window.removeEventListener('scroll', capt);
-		document.removeEventListener("AngularReady", detach);
-	  };
 	  document.addEventListener("AngularReady", detach);
 	};
+
+  function detach() {
+		window.removeEventListener('scroll', capt);
+		document.removeEventListener("AngularReady", detach);
+  };
 
 	window.addEventListener('scroll', capt);
 
 	window.addEventListener('AngularReady', scullyDiscountFlashPreventionContentScript);
 	function scullyDiscountFlashPreventionContentScript(){
 	  document.documentElement.scrollTop = window['ScullyIO-scrollPosition'];
+	  window.removeEventListener('scroll', capt);
 		document.body.classList.add('${LoadedClass}');
 		const tempAppRoot = document.querySelector('${AppRootSelector}-scully');
     tempAppRoot.parentNode.removeChild(tempAppRoot);

--- a/libs/scully/package.json
+++ b/libs/scully/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully",
-  "version": "0.0.99",
+  "version": "0.0.101",
   "description": "Scully CLI",
   "repository": {
     "type": "GIT",

--- a/tests/jest/src/__tests__/__snapshots__/docsThere.spec.ts.snap
+++ b/tests/jest/src/__tests__/__snapshots__/docsThere.spec.ts.snap
@@ -21,10 +21,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -551,10 +551,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -1077,10 +1077,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -1730,10 +1730,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -3045,10 +3045,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -3945,10 +3945,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -4948,10 +4948,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -5537,10 +5537,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -6123,10 +6123,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -7040,10 +7040,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -8156,10 +8156,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -8807,10 +8807,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -9336,10 +9336,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -11585,10 +11585,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -13832,10 +13832,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -14398,10 +14398,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -14996,10 +14996,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -15593,10 +15593,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -16284,10 +16284,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -16972,10 +16972,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -17562,10 +17562,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -18132,10 +18132,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -18699,10 +18699,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -19239,6 +19239,13 @@ exports[`docsSite should have content for all markdown files check html for mark
                         404
                       </a>
                     </li>
+                    <li ="">
+                      <a href="/docs/scully-cmd-line#prod"
+                         =""
+                      >
+                        prod
+                      </a>
+                    </li>
                   </ul>
                 </li>
               </ul>
@@ -19717,6 +19724,26 @@ If the Scully server gets a request for a route(file) that does not exists on th
                 </code>
                 will use the unhandled routes only
               </p>
+              <h2 id="prod"
+                  =""
+              >
+                prod
+              </h2>
+              <pre ="">
+                <code class="language-bash"
+                      =""
+                >
+                  npx scully --prod
+                </code>
+              </pre>
+              <p ="">
+                With the prod flag you can use a different config for your scully config and plugins.
+                <a href="https://github.com/scullyio/scully/blob/main/scully.scully-docs.config.ts#L15"
+                   =""
+                >
+                  example
+                </a>
+              </p>
               <script>
                 try {window['scullyContent'] = {cssId:"",html:document.body.innerHTML.split('
                 <!--scullyContent-begin-->')[1].split('
@@ -19844,10 +19871,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -21306,10 +21333,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -22460,10 +22487,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -23014,10 +23041,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -23607,10 +23634,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.7da90eb75d2b45cc1b76.css"
+          href="styles.bf691284a175e9825a45.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>

--- a/tests/jest/src/__tests__/__snapshots__/docsThere.spec.ts.snap
+++ b/tests/jest/src/__tests__/__snapshots__/docsThere.spec.ts.snap
@@ -21,10 +21,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -551,10 +551,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -1077,10 +1077,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -1730,10 +1730,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -3045,10 +3045,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -3945,10 +3945,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -4948,10 +4948,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -5537,10 +5537,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -6123,10 +6123,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -7040,10 +7040,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -8156,10 +8156,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -8807,10 +8807,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -9336,10 +9336,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -11585,10 +11585,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -13832,10 +13832,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -14398,10 +14398,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -14996,10 +14996,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -15593,10 +15593,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -16284,10 +16284,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -16972,10 +16972,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -17562,10 +17562,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -18132,10 +18132,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -18699,10 +18699,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -19239,13 +19239,6 @@ exports[`docsSite should have content for all markdown files check html for mark
                         404
                       </a>
                     </li>
-                    <li ="">
-                      <a href="/docs/scully-cmd-line#prod"
-                         =""
-                      >
-                        prod
-                      </a>
-                    </li>
                   </ul>
                 </li>
               </ul>
@@ -19724,26 +19717,6 @@ If the Scully server gets a request for a route(file) that does not exists on th
                 </code>
                 will use the unhandled routes only
               </p>
-              <h2 id="prod"
-                  =""
-              >
-                prod
-              </h2>
-              <pre ="">
-                <code class="language-bash"
-                      =""
-                >
-                  npx scully --prod
-                </code>
-              </pre>
-              <p ="">
-                With the prod flag you can use a different config for your scully config and plugins.
-                <a href="https://github.com/scullyio/scully/blob/main/scully.scully-docs.config.ts#L15"
-                   =""
-                >
-                  example
-                </a>
-              </p>
               <script>
                 try {window['scullyContent'] = {cssId:"",html:document.body.innerHTML.split('
                 <!--scullyContent-begin-->')[1].split('
@@ -19871,10 +19844,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -21333,10 +21306,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -22487,10 +22460,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -23041,10 +23014,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>
@@ -23634,10 +23607,10 @@ exports[`docsSite should have content for all markdown files check html for mark
           href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
     >
     <link rel="stylesheet"
-          href="styles.bf691284a175e9825a45.css"
+          href="styles.7da90eb75d2b45cc1b76.css"
     >
     <style>
-      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.b01bbd69c8fe3262435d.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
+      []{display:grid;height:100vh;grid-template-rows:60px 1fr 60px}[] > header[]{display:grid;margin:0;padding:0 20px;grid-template-columns:120px 1fr;place-items:center right;overflow:none}footer[]   h3[], header[]   h1[]{margin:0}main[]{padding:10px;background-image:url(scully-bg-s.dd10fb624cb5a93cddd6.svg);background-size:cover}.github[]{float:right;margin-top:10px;margin-left:20px}footer[]{padding-top:48px;min-height:250px;display:grid;grid-template-columns:25% 15% 15% 15% 25%;background:var(--scully-green-wash)}.footer-1[]{grid-column-start:2;grid-column-end:2;text-align:center}.footer-2[]{grid-column-start:3;grid-column-end:3;text-align:center}.footer-3[]{grid-column-start:4;grid-column-end:4;text-align:center}a[]{text-decoration:none;color:var(--scully-darkgray);cursor:pointer}.footer-1[] > h3[], .footer-2[] > h3[], .footer-3[] > h3[]{color:var(--scully-green);margin-bottom:10px}@media (max-width:1024px){footer[]{grid-template-columns:16px 1fr 1fr 1fr 16px}nav[]{transform:scale(.9)}}header[]{background:#000;color:#fff;min-height:90px}
     </style>
     <style>
     </style>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Sometimes when use the flash-prevention the scroll event continue working after run angular
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
