### PR TITLE
(fix/schematics): package.json generated scripts

### DIFF
--- a/libs/scully-schematics/src/scully/index.ts
+++ b/libs/scully-schematics/src/scully/index.ts
@@ -25,7 +25,7 @@ const modifyPackageJson = (options: Schema) => (tree: Tree, context: SchematicCo
   defaultProjectName = getProject(tree, 'defaultProject', angularJSON);
   projectName = getProject(tree, options.project, angularJSON);
 
-  const params = projectName === defaultProjectName ? '' : ` --projectName=${projectName}`;
+  const params = projectName === defaultProjectName ? '' : ` --project ${projectName}`;
   const jsonContent = getPackageJson(tree);
   jsonContent.scripts.scully = 'scully' + params;
   jsonContent.scripts['scully:serve'] = 'scully serve' + params;


### PR DESCRIPTION
Documentation is right (https://scully.io/docs/scully-cmd-line/) for v1.0.0-beta.0, and says `--project ` as the right way to launch those 2 scripts.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When adding scully capabilities (`ng add @scullyio/init`) to an existing Angular project (**not default project**) in a Nx mono-repo, when running `npm run scully`, it simply fails, because it tries to launch `scully --projectName=<projectName>`. Same for `npm run scully:serve`.

Issue Number: N/A

## What is the new behavior?

It works as expected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Tested on Angular 9.1.9 project on a Windows 10 machine.