### PR TITLE
fix(scully): Add wait time before spawning new browser instance

### DIFF
--- a/libs/scully/src/lib/renderPlugins/launchedBrowser.ts
+++ b/libs/scully/src/lib/renderPlugins/launchedBrowser.ts
@@ -1,6 +1,6 @@
 import { Browser, launch, LaunchOptions } from 'puppeteer';
-import { BehaviorSubject, from, merge, Observable } from 'rxjs';
-import { filter, shareReplay, switchMap, take, tap, throttleTime } from 'rxjs/operators';
+import { BehaviorSubject, from, merge, Observable, interval } from 'rxjs';
+import { filter, shareReplay, switchMap, take, tap, throttleTime, delayWhen } from 'rxjs/operators';
 import { showBrowser } from '../utils/cli-options';
 import { loadConfig, scullyConfig } from '../utils/config';
 import { green, log, logError } from '../utils/log';
@@ -96,7 +96,14 @@ function obsBrowser(options: LaunchOptions = scullyConfig.puppeteerLaunchOptions
         filter(() => !isLaunching),
         // tap(() => log(green('relaunch cmd received'))),
         /** the long trottletime is to cater for the concurrently running browsers to crash and burn. */
-        throttleTime(15000)
+        delayWhen(() => {
+          let intervalLength = 15000;
+          if (!browser) {
+            intervalLength = 0;
+          }
+
+          return interval(intervalLength);
+        })
       )
       .subscribe({
         next: () => {


### PR DESCRIPTION
If there are more than 500 routes rendered, when this limit is reached
a new browser instance is spawned. The async jobs rendering the
routes at that moment are not waited and thus they are failing with
exception causing the process to stop.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If there are more than 500 routes rendered, when this limit is reached
a new browser instance is spawned. The async code rendering the
routes at that moment are not waited and thus they are failing with
exception causing the process to stop.

Issue Number: N/A

## What is the new behavior?
If there are more than 500 routes rendered, when this limit is reached
there is a 15000 millisecond wait time before a new browser instance 
is spawned. This allows time for current remaining async routes to finish
rendering and processing before the old instance is killed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
