### PR TITLE
style(schematics): fix typo wls to wsl

### DIFF
--- a/docs/learn/getting-started/installation.md
+++ b/docs/learn/getting-started/installation.md
@@ -48,7 +48,7 @@ The [JSON Plugin](/docs/Reference/plugins/built-in-plugins/json) is an example o
 
 ### WSL Pre-Requisites
 
-WLS is a Linux subsystem within Windows, therefore, it does not come with the entire pack installed, because of that Puppeteer needs chrome to be installed within the subsystem.
+WSL is a Linux subsystem within Windows, therefore, it does not come with the entire pack installed, because of that Puppeteer needs chrome to be installed within the subsystem.
 
 ```bash
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb

--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -51,8 +51,8 @@ if (clientOS.includes('microsoft') && process.platform === 'linux') {
   logWarn(`
 **********************************************************
 **********************************************************
-You are using "${yellow(`WLS`)}" as a terminal, if you get an
-error please read the pre-requisites for Microsoft WLS.
+You are using "${yellow(`WSL`)}" as a terminal, if you get an
+error please read the pre-requisites for Microsoft WSL.
 https://scully.io/docs/learn/getting-started/installation/
 **********************************************************
 **********************************************************


### PR DESCRIPTION
I encountered a basic typo issue with Windows Subsystem Linux short world.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe:
Typo error.

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
