### PR TITLE
feat(scully): cmdLine option to set logSeverity

### DIFF
--- a/docs/Reference/command-line-options.md
+++ b/docs/Reference/command-line-options.md
@@ -157,3 +157,20 @@ npx scully --pluginsError=false
 
 Show the error from the plugin, but continue rendering.
 If you do not use the flag (true by default) when you have an error in any plugin, Scully will exit.
+
+### logSeverity
+
+Overrides the logSeverity from the config file
+
+```bash
+npx scully --logSeverity=none
+```
+
+Available options:
+
+| option    | result                                             |
+| --------- | -------------------------------------------------- |
+| `normal`  | Logs everything                                    |
+| `warning` | Logs warnings and errors only                      |
+| `error`   | Logs only errors                                   |
+| `none`    | Logs nothing, no `scully.log` file will be created |

--- a/docs/Reference/config.md
+++ b/docs/Reference/config.md
@@ -110,12 +110,14 @@ This option can be modified according to your needs.
 #### logFileSeverity
 
 Determines what of the Scully output will be written into the `scully.log` file in the root of the project.
+Due to the fact that this option is _in_ the config, the default `warning` setting will be used until the config is fully processed. If there are errors and/or warnings raised during the processing fo the config, those _will_ be logged. You can override this behavior by using the `--logSeverity` command line parameter.
 
-| option | result                        |
-| ------ | ----------------------------- |
-| `0`    | Logs everything               |
-| `1`    | Logs warnings and errors only |
-| `2`    | Logs errors only              |
+| option    | result                                  |
+| --------- | --------------------------------------- |
+| `normal`  | Logs everything                         |
+| `warning` | Logs warnings and errors only           |
+| `error`   | Logs only errors                        |
+| `none`    | Logs nothing, after config is processed |
 
 #### routes
 

--- a/libs/scully/src/lib/utils/cli-options.ts
+++ b/libs/scully/src/lib/utils/cli-options.ts
@@ -8,6 +8,7 @@ export const {
   folder,
   handle404,
   hostName,
+  logSeverity,
   noLog,
   noPrompt,
   openNavigator,
@@ -173,7 +174,9 @@ export const {
     .boolean('prod')
     .alias('prod', 'Production')
     .default('prod', false)
-    .describe('prod', 'Use prod mode for Scully').argv;
+    .describe('prod', 'Use prod mode for Scully')
+    .choices('logSeverity', ['normal', 'warning', 'error', 'none'])
+    .describe('logSeverity', 'select the log-severity level').argv;
 
 yargs.help();
 

--- a/libs/scully/src/lib/utils/config.ts
+++ b/libs/scully/src/lib/utils/config.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { compileConfig } from './compileConfig';
 import { findAngularJsonPath } from './findAngularJsonPath';
 import { ScullyConfig } from './interfacesandenums';
-import { logError, LogSeverity, logWarn, yellow } from './log';
+import { logError, logWarn, yellow } from './log';
 import { readAngularJson } from './read-anguar-json';
 import { validateConfig } from './validateConfig';
 export const angularRoot = findAngularJsonPath();
@@ -14,7 +14,7 @@ export const scullyDefaults: Partial<ScullyConfig> = {
   bareProject: false,
   homeFolder: angularRoot,
   outDir: join(angularRoot, './dist/static/'),
-  logFileSeverity: LogSeverity.warning,
+  logFileSeverity: 'warning',
   inlineStateOnly: false,
   thumbnails: false,
   maxRenderThreads: cpus().length,

--- a/scully.scully-docs.config.ts
+++ b/scully.scully-docs.config.ts
@@ -47,10 +47,9 @@ setPluginConfig<RemoveScriptsConfig>(removeScripts, {
 });
 
 export const config: ScullyConfig = {
-  logFileSeverity: 'none',
   projectRoot: './apps/scully-docs/src',
   projectName: 'scully-docs',
-  // outDir: './dist/static/doc-sites',
+  outDir: './dist/static/doc-sites',
   distFolder: './dist/apps/scully-docs',
   defaultPostRenderers,
   routes: {

--- a/scully.scully-docs.config.ts
+++ b/scully.scully-docs.config.ts
@@ -47,9 +47,10 @@ setPluginConfig<RemoveScriptsConfig>(removeScripts, {
 });
 
 export const config: ScullyConfig = {
+  logFileSeverity: 'none',
   projectRoot: './apps/scully-docs/src',
   projectName: 'scully-docs',
-  outDir: './dist/static/doc-sites',
+  // outDir: './dist/static/doc-sites',
   distFolder: './dist/apps/scully-docs',
   defaultPostRenderers,
   routes: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
see #986 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
documented behavior, added CLI option to override.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If you have a `logFileSeverity` setting in your config file, it now takes a type:
```typescript
export type LogSeverity = 'normal' | 'warning' | 'error' | 'none';
```
instead of an enum. 


## Other information
