### PR TITLE
feat(scully): only write routes in watch mode if they are updated

### DIFF
--- a/libs/scully/src/lib/systemPlugins/storeRoutes.ts
+++ b/libs/scully/src/lib/systemPlugins/storeRoutes.ts
@@ -1,32 +1,26 @@
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { registerPlugin, scullySystem } from '../pluginManagement';
 import { HandledRoute } from '../routerPlugins/handledRoute.interface';
 import { watch } from '../utils/cli-options';
 import { scullyConfig } from '../utils/config';
 import { createFolderFor } from '../utils/createFolderFor';
-import { log, logError, logWarn, yellow, printProgress } from '../utils/log';
-import { registerPlugin, scullySystem } from '../pluginManagement';
+import { log, logError, printProgress, yellow } from '../utils/log';
 
 export const routesFileName = '/assets/scully-routes.json';
 
 export const storeRoutes = Symbol('storeRoutes');
 registerPlugin(scullySystem, storeRoutes, storeRoutesPlugin);
 async function storeRoutesPlugin(routes: HandledRoute[]) {
+  /** in the angular source folder */
+  const srcFile = join(scullyConfig.homeFolder, scullyConfig.sourceRoot, routesFileName);
   const files = [
+    srcFile,
     /** in the scully outfolder */
     join(scullyConfig.outDir, routesFileName),
     /** in the angular dist folder */
     join(scullyConfig.homeFolder, scullyConfig.distFolder, routesFileName),
   ];
-  if (!watch) {
-    /** in the angular source folder */
-    files.push(
-      /** in the angular source folder */
-      join(scullyConfig.homeFolder, scullyConfig.sourceRoot, routesFileName)
-    );
-  } else {
-    logWarn(`running in watch-mode, routefile in source assets will not be updated`);
-  }
   try {
     const jsonResult = JSON.stringify(
       routes.map((r) => ({
@@ -35,6 +29,19 @@ async function storeRoutesPlugin(routes: HandledRoute[]) {
         ...r.data,
       }))
     );
+    if (watch) {
+      /** we need to compare in watch mode, so we don't enter an endless loop where the angular CLI and the Scully CLI keep updating ech other */
+      try {
+        const existing = readFileSync(srcFile).toString('utf-8').trim();
+        if (jsonResult.trim() === existing) {
+          /** the same. done, don't write */
+          log('keep existing route file');
+          return;
+        }
+      } catch (e) {
+        /** there is an error, that mean a difference, just write the files */
+      }
+    }
     const write = (file, i, collection) => {
       createFolderFor(file);
       printProgress(i + 1, 'Creating Route List:', collection.length);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
in watch mode rotues are not written into the angular folder
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Routes are written after an actual update, not if those are the same. Prevents the infinitive loop

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
