### PR TITLE
docs: fix broken internal links

### DIFF
--- a/docs/Reference/legacy-support/overview.md
+++ b/docs/Reference/legacy-support/overview.md
@@ -6,5 +6,5 @@ position: 900
 
 # Scully Legacy support
 
-- [Angular v8](/docs/Reference/legacy-support/angular-v8.md)
-- [IE polyfills](/docs/Reference/legacy-support/polyfills.md)
+- [Angular v8](/docs/Reference/legacy-support/angular-v8)
+- [IE polyfills](/docs/Reference/legacy-support/polyfills)

--- a/docs/Reference/ngLib/overview.md
+++ b/docs/Reference/ngLib/overview.md
@@ -9,8 +9,8 @@ position: 100
 When you install Scully using the `ng add` schematics, our Angular library will also be installed.
 The library has some intergration features that enable you to utilize the full potential of Scully.
 
-- [Idle-monitor](/docs/Reference/ngLib/idle-monitor-service.md)
-- [Scully-content](/docs/Reference/ngLib/scully-content-component.md)
-- [Idle-monitor](/docs/Reference/ngLib/idle-monitor-service.md)
-- [TransferStateService](/docs/Reference/ngLib/transfer-state-service.md)
-- [Utilities](/docs/Reference/ngLib/utility-methods.md)
+- [Idle-monitor](/docs/Reference/ngLib/idle-monitor-service)
+- [Scully-content](/docs/Reference/ngLib/scully-content-component)
+- [Idle-monitor](/docs/Reference/ngLib/idle-monitor-service)
+- [TransferStateService](/docs/Reference/ngLib/transfer-state-service)
+- [Utilities](/docs/Reference/ngLib/utility-methods)

--- a/docs/Reference/overview.md
+++ b/docs/Reference/overview.md
@@ -6,5 +6,5 @@ position: 200
 
 # Scully reference
 
-- [NG lib](/docs/Reference/ngLib/overview.md)
-- [Legacy support](/docs/Reference/legacy-support/overview.md)
+- [NG lib](/docs/Reference/ngLib/overview)
+- [Legacy support](/docs/Reference/legacy-support/overview)

--- a/docs/Reference/plugins/built-in-plugins/router-render.md
+++ b/docs/Reference/plugins/built-in-plugins/router-render.md
@@ -29,7 +29,7 @@ To use the `router-render` you need to add in your app config the routes and sen
     },
 ```
 
-And you need to register the plugin, the plugin system uses the registerPlugin for that (for more information check [register a new plugin](/docs/Reference/plugins/custom-plugins/register-a-new-plugin.md) docs)
+And you need to register the plugin, the plugin system uses the registerPlugin for that (for more information check [register a new plugin](/docs/Reference/plugins/custom-plugins/register-a-new-plugin) docs)
 
 `scully.{{your_app}}.config.ts`
 

--- a/docs/Reference/plugins/custom-plugins/overview.md
+++ b/docs/Reference/plugins/custom-plugins/overview.md
@@ -10,8 +10,8 @@ position: 130
 The plugin system allows you to define your own plugins in order to have a fine-grained control over Scully's pre-render process.
 There are six main types of plugins, and you can make your own custom plugins off any of those types.
 
-First, [create the plugin function](/docs/Reference/plugins/custom-plugins/create-a-plugin-function.md).
+First, [create the plugin function](/docs/Reference/plugins/custom-plugins/create-a-plugin-function).
 
-Second, [register a new plugin](/docs/Reference/plugins/custom-plugins/register-a-new-plugin.md).
+Second, [register a new plugin](/docs/Reference/plugins/custom-plugins/register-a-new-plugin).
 
 Finally, [use a custom plugin](/docs/Reference/plugins/custom-plugins/use-a-custom-plugin).

--- a/docs/Reference/plugins/custom-plugins/register-a-new-plugin.md
+++ b/docs/Reference/plugins/custom-plugins/register-a-new-plugin.md
@@ -13,5 +13,5 @@ position: 10
 
 ## Overview
 
-To register a new plugin into our plugin system the [registerPlugin function](/docs/Reference/scully-api/registerPlugin.md) is your way in.
+To register a new plugin into our plugin system the [registerPlugin function](/docs/Reference/scully-api/registerPlugin) is your way in.
 You can see all the options available in the API docs.

--- a/docs/Reference/plugins/overview.md
+++ b/docs/Reference/plugins/overview.md
@@ -12,7 +12,7 @@ position: 120
 The plugin system allows you to define your own plugins in order to have a fine-grained control over Scully's pre-render process.
 There are six main types of plugins, and you can make your own custom plugins off any of those types.
 
-When you want to [build your own plugin](/docs/Reference/plugins/custom-plugins/overview.md)
+When you want to [build your own plugin](/docs/Reference/plugins/custom-plugins/overview)
 
 ## Types
 
@@ -25,11 +25,11 @@ When you want to [build your own plugin](/docs/Reference/plugins/custom-plugins/
 `render` plugins are used to transform the rendered HTML.
 After the Angular application renders, the HTML content is passed to a `render` plugin where it can be further modified.
 
-### [Route process](/docs/Reference/plugins/types/route-process.md)
+### [Route process](/docs/Reference/plugins/types/route-process)
 
 'routeProcess' plugins are plugins that can modify the handled route array, before rendering the routes starts
 
-#### [Content or File handler plugins](/docs/Reference/plugins/types/fileHandler.md)
+#### [Content or File handler plugins](/docs/Reference/plugins/types/fileHandler)
 
 `fileHandler` plugins are used by the [`contentFolder`](/docs/Reference/plugins/built-in-plugins/contentFolder) plugin during the render process. The [`contentFolder`](/docs/Reference/plugins/built-in-plugins/contentFolder) plugin processes the folders for markdown files or other file type the folders may contain. The render process processes any existing `fileHandler` plugin for any file extension type.
 

--- a/docs/Reference/plugins/types/overview.md
+++ b/docs/Reference/plugins/types/overview.md
@@ -31,7 +31,7 @@ There are five main types of plugins which allow code to be injected into variou
 `render` plugins are used to transform the rendered HTML.  
 After the Angular application renders, the HTML content is passed to a `render` plugin where it can be further modified.
 
-#### [`fileHandler`](/docs/Reference/plugins/types/fileHandler.md)
+#### [`fileHandler`](/docs/Reference/plugins/types/fileHandler)
 
 `fileHandler` plugins are used by the [`contentFolder`](/docs/Reference/plugins/built-in-plugins/contentFolder) plugin during the render process. The [`contentFolder`](/docs/Reference/plugins/built-in-plugins/contentFolder) plugin processes the folders for markdown files or other file type the folders may contain. The render process processes any existing `fileHandler` plugin for any file extension type.
 

--- a/docs/Reference/schematics/overview.md
+++ b/docs/Reference/schematics/overview.md
@@ -9,6 +9,6 @@ position: 100
 
 Scully comes with a number of schematics to support the integration with your Angular app.
 
-[Install Scully in your Angular app](/docs/Reference/schematics/create-scully-files-with-ng-add.md).
-[Create a blog](/docs/Reference/schematics/create-blog-config.md).
-[Create markdown skeleton](/docs/Reference/schematics/create-markdown-files-and-skeleton.md).
+[Install Scully in your Angular app](/docs/Reference/schematics/create-scully-files-with-ng-add).
+[Create a blog](/docs/Reference/schematics/create-blog-config).
+[Create markdown skeleton](/docs/Reference/schematics/create-markdown-files-and-skeleton).

--- a/docs/Reference/utilities/overview.md
+++ b/docs/Reference/utilities/overview.md
@@ -12,6 +12,6 @@ position: 170
 Scully works well in combination with other tools and utilities:
 
 - Github Actions:
-  - [Scully Publish](/docs/Reference/utilities/scully-publish.md)
+  - [Scully Publish](/docs/Reference/utilities/scully-publish)
 - Syntax Highlighting:
-  - [PrismJS](/docs/Reference/utilities/prism-js.md)
+  - [PrismJS](/docs/Reference/utilities/prism-js)

--- a/docs/concepts/handled-routes.md
+++ b/docs/concepts/handled-routes.md
@@ -7,7 +7,7 @@ title: Handled Routes
 
 # Handled routes
 
-When we take an [unhandled route](/docs/concepts/unhandled-routes.md), and run that through a [router plugin](/docs/Reference/plugins/types/router.md), on the other end should come out a handled route. This means a plugin would get a route like this:
+When we take an [unhandled route](/docs/concepts/unhandled-routes), and run that through a [router plugin](/docs/Reference/plugins/types/router), on the other end should come out a handled route. This means a plugin would get a route like this:
 
 ```html
 /user/:id

--- a/docs/concepts/handled-routes_es.md
+++ b/docs/concepts/handled-routes_es.md
@@ -7,7 +7,7 @@ title: Controlando Rutas
 
 # Controlando Rutas
 
-Cuando tomamos una [ruta no controlada](/docs/concepts/unhandled-routes.md), y ejecuta utilizando el [plugin de router](/docs/Reference/plugins/types/router.md), al terminar su ejecución debería existir una ruta controlada. Esto significa que el plugin toma una ruta como esta:
+Cuando tomamos una [ruta no controlada](/docs/concepts/unhandled-routes), y ejecuta utilizando el [plugin de router](/docs/Reference/plugins/types/router), al terminar su ejecución debería existir una ruta controlada. Esto significa que el plugin toma una ruta como esta:
 
 ```html
 /user/:id

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -9,6 +9,6 @@ title: Concepts
 
 In this section, we explain the following Scully concepts in-depth.
 
-- [the Scully proccess](/docs/concepts/process.md) explains step by step what happens when you run scully.
-- [unhandled routes](/docs/concepts/unhandled-routes.md) explains all about `unhandled routes`
-- [handled routes](/docs/concepts/handled-routes.md) explains all about `handled routes`
+- [the Scully proccess](/docs/concepts/process) explains step by step what happens when you run scully.
+- [unhandled routes](/docs/concepts/unhandled-routes) explains all about `unhandled routes`
+- [handled routes](/docs/concepts/handled-routes) explains all about `handled routes`

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -7,7 +7,7 @@ title: Plugins
 
 # Scully plugins.
 
-This is a high-level overview about plugins. For details see the [plugin section](/docs/Reference/plugins/overview.md) in the reference.
+This is a high-level overview about plugins. For details see the [plugin section](/docs/Reference/plugins/overview) in the reference.
 
 ## About plugins.
 

--- a/docs/concepts/process.md
+++ b/docs/concepts/process.md
@@ -30,7 +30,7 @@ Please note that not all of those tasks might need to run every time. Scully wil
 For each [handled route] take the following steps:
 
 1. (optional) Run the preRender function (can be provided in the config for this route), stop processing when `false` is returned. This function might add data to the [handled route], or even change the plugins used. Please note that the route will still be present in the `scully.routes.json` file.
-2. Determine if there is a special [renderPlugin](/docs/Reference/plugins/types/render.md)
+2. Determine if there is a special [renderPlugin](/docs/Reference/plugins/types/render)
 3. Use the render plugin from step 2 to return the HTML for the given [handled route]
 4. Take the resulting HTML, and invoke all the render plugins for this route in the given order. Each plugin receives an HTML string, and the handledRoute and returns an HTML string.
 5. Use the `WriteToStorage` plugin to store the result on local FS. The `WriteToStorage` plugin translates the route.route to a file location. If the content has `transferState` inside, it will extract this, and save it along the `index.html` as `data.json` in the designated location for this route.

--- a/docs/learn/create-a-blog/add-blog-support.md
+++ b/docs/learn/create-a-blog/add-blog-support.md
@@ -98,6 +98,6 @@ const routes: Routes = [
 
 ## Extending functionality
 
-Scully works well in combination with other tools and [utilities](/docs/Reference/utilities/overview.md).
+Scully works well in combination with other tools and [utilities](/docs/Reference/utilities/overview).
 
 For instance, if the markdown content includes code blocks, and you want to highlight them; use a utility.

--- a/docs/learn/create-a-blog/add-blog-support_es.md
+++ b/docs/learn/create-a-blog/add-blog-support_es.md
@@ -98,6 +98,6 @@ const routes: Routes = [
 
 ## Extendiendo funcionalidad
 
-Scully funciona muy bien con otras herramientas y [utilidades](/docs/Reference/utilities/overview.md).
+Scully funciona muy bien con otras herramientas y [utilidades](/docs/Reference/utilities/overview).
 
 Por ejemplo, si el contenido markdown incluye bloques de código y quieres resaltarlo, entonces utilizarás una utilidad.

--- a/docs/learn/create-a-blog/overview.md
+++ b/docs/learn/create-a-blog/overview.md
@@ -6,4 +6,4 @@ position: 20
 
 # Creating a blog
 
-Start off with [adding blog support](/docs/learn/create-a-blog/add-blog-support.md). After that, you might want to find out how to [add a new post](/docs/learn/create-a-blog/generate-new-blog-posts.md), or how to [use blog post meta-data](/docs/learn/create-a-blog/use-blog-post-data-in-template.md).
+Start off with [adding blog support](/docs/learn/create-a-blog/add-blog-support). After that, you might want to find out how to [add a new post](/docs/learn/create-a-blog/generate-new-blog-posts), or how to [use blog post meta-data](/docs/learn/create-a-blog/use-blog-post-data-in-template).

--- a/docs/learn/create-a-blog/overview_es.md
+++ b/docs/learn/create-a-blog/overview_es.md
@@ -6,4 +6,4 @@ position: 20
 
 # Creando un blog
 
-Comienza con [agregar soporte para blog](/docs/learn/create-a-blog/add-blog-support.md). Luego de eso, seguramente desees [agregar un nuevo artículo](/docs/learn/create-a-blog/generate-new-blog-posts.md), o cómo [usar los metadatos de un artículo](/docs/learn/create-a-blog/use-blog-post-data-in-template.md).
+Comienza con [agregar soporte para blog](/docs/learn/create-a-blog/add-blog-support). Luego de eso, seguramente desees [agregar un nuevo artículo](/docs/learn/create-a-blog/generate-new-blog-posts), o cómo [usar los metadatos de un artículo](/docs/learn/create-a-blog/use-blog-post-data-in-template).

--- a/docs/learn/getting-started/tips-for-testing.md
+++ b/docs/learn/getting-started/tips-for-testing.md
@@ -40,4 +40,4 @@ http://localhost:1864/a/path/in/my/app
 ```
 
 and check the content of that page. If that is off, the problem is in your Angular app, and you need to fix it there.
-When this page looks correct, but the static file does reflect only a partial result, there is probably an issue where zoneJS can't be used to detect your apps idle state. (idle state in this case means, your app is ready, everything is rendered to screen, and we are waiting for the user to do something). See [adding custom mechanisms](/docs/Reference/config.md) how to handle this situation.
+When this page looks correct, but the static file does reflect only a partial result, there is probably an issue where zoneJS can't be used to detect your apps idle state. (idle state in this case means, your app is ready, everything is rendered to screen, and we are waiting for the user to do something). See [adding custom mechanisms](/docs/Reference/config) how to handle this situation.

--- a/docs/learn/getting-started/tips-for-testing_es.md
+++ b/docs/learn/getting-started/tips-for-testing_es.md
@@ -40,4 +40,4 @@ http://localhost:1864/a/path/in/my/app
 ```
 
 luego chequea el contenido de esa página. Si la url está deshabilitada, entonces el problema se encuentra en la aplicación Angular y necesitas solucionarlo allí.
-Cuando la página parece correcta, pero el archivo estático refleja sólo algunos resultados, es muy probable que el problema se encuentre porque zoneJS no puede detectar el estado idle de tu aplicación (un estado idle, en este caso, significa que la aplicación está lista, todo es tá renderizado en la pantalla y estamos esperando que el usuario haga algo). Vea [agregando mecanismos personalizados](/docs/Reference/config.md) para manejar esta situación.
+Cuando la página parece correcta, pero el archivo estático refleja sólo algunos resultados, es muy probable que el problema se encuentre porque zoneJS no puede detectar el estado idle de tu aplicación (un estado idle, en este caso, significa que la aplicación está lista, todo es tá renderizado en la pantalla y estamos esperando que el usuario haga algo). Vea [agregando mecanismos personalizados](/docs/Reference/config) para manejar esta situación.

--- a/docs/learn/introduction_es.md
+++ b/docs/learn/introduction_es.md
@@ -26,6 +26,6 @@ Scully analiza la estructura de rutas de su aplicación Angular compilada y gene
 
 Scully proporciona una serie de utilidades para manipular páginas estáticas, como:
 
-- [Renderizar archivos .md como .html](/docs/learn/create-a-blog/add-blog-support.md) y [extraer datos de rutas generadas](/docs/learn/create-a-blog/use-blog-post-data-in-template.md) para usar en plantillas Angular a través de simples observable.
+- [Renderizar archivos .md como .html](/docs/learn/create-a-blog/add-blog-support) y [extraer datos de rutas generadas](/docs/learn/create-a-blog/use-blog-post-data-in-template) para usar en plantillas Angular a través de simples observable.
 - Un [sistema de complementos flexible](/docs/Reference/plugins/overview) para hornear tu propia funcionalidad en los procesos de Scully.
-- Varios [Angular schematics](/docs/Reference/schematics/create-scully-files-with-ng-add.md) para hacer su uso lo más <strong>fácil posible!</strong>
+- Varios [Angular schematics](/docs/Reference/schematics/create-scully-files-with-ng-add) para hacer su uso lo más <strong>fácil posible!</strong>

--- a/docs/learn/overview.md
+++ b/docs/learn/overview.md
@@ -22,7 +22,7 @@ Building the Fastest Angular Apps Possible
 
 ## How does it work?
 
-Scully analyzes the route structure of your Angular application and uses that to create a list of routes. (you can add those manually if needed). Then it will go over this list, and generate an `index.html` for each of them. See [the Scully process](/docs/concepts/process.md) for in-depth details
+Scully analyzes the route structure of your Angular application and uses that to create a list of routes. (you can add those manually if needed). Then it will go over this list, and generate an `index.html` for each of them. See [the Scully process](/docs/concepts/process) for in-depth details
 
 ## How do I use it?
 

--- a/docs/learn/overview_es.md
+++ b/docs/learn/overview_es.md
@@ -22,7 +22,7 @@ Crear Aplicaciones Angular más Rápidas es Posible
 
 ## ¿Cómo funciona?
 
-Scully analiza la estructura de rutas de tu aplicación Angular y a partir de eso, crea una lista de rutas (que puedes agregar manualmente si es necesario). Entonces, utilizando esta lista, generará un `index.html` por cada ruta. Ver [El proceso Scully](/docs/concepts/process.md) para más detalles
+Scully analiza la estructura de rutas de tu aplicación Angular y a partir de eso, crea una lista de rutas (que puedes agregar manualmente si es necesario). Entonces, utilizando esta lista, generará un `index.html` por cada ruta. Ver [El proceso Scully](/docs/concepts/process) para más detalles
 
 ## ¿Cómo lo uso?
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Internal links for reference docs are broken.
https://scully.io/docs/Reference/overview/ on this page `NG Lib` and `Legacy Support` links are not working. The same issue is there for other documents.
One scenario I have marked is Internal Links which have `.md` at the end in the doc is not working.

Issue Number: 

## What is the new behavior?

Updated the internal links. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
