### PR TITLE
fix(scully): fix docs-link plugin

### DIFF
--- a/libs/plugins/docs-link-update/src/lib/plugins-docs-link-update.ts
+++ b/libs/plugins/docs-link-update/src/lib/plugins-docs-link-update.ts
@@ -11,8 +11,12 @@ const docsLinkPlugin = async (html: string, options: HandledRoute): Promise<stri
     anchors.forEach((a) => {
       const href = a.getAttribute('href');
       if (href && href.toLowerCase().endsWith('.md') && !href.toLowerCase().startsWith('http')) {
-        const myBase = dropOpeningSlash(options.route.substring(0, options.route.lastIndexOf('/')));
-        const newRef = `${myBase}/${href.slice(0, -3)}`;
+        let newRef = '';
+        if (!href.startsWith('/')) {
+          const myBase = dropOpeningSlash(options.route.substring(0, options.route.lastIndexOf('/')));
+          newRef = `${myBase}/`;
+        }
+        newRef = newRef + href.slice(0, -3);
         a.setAttribute('href', newRef);
       }
       if (href && href.startsWith('#')) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Hyperlinks for internal documents (`.md`) are not rendered properly. 
If we have link as `[NG lib](/docs/Reference/ngLib/overview.md)` in the markdown document file, then this link is transformed as `/docs/Reference//docs/Reference/ngLib/overview` in static HTML which creates the broken links.

Issue Number: N/A

## What is the new behavior?
Handle both relative and full path document link
For example, We can write `NG Lib` link in `/docs/Reference/overview.md` file as below,
- Link with full path `[NG lib](/docs/Reference/ngLib/overview.md)`  will be transformed as `/docs/Reference/ngLib/overview`.
- Link with relative path  `[NG lib](ngLib/overview.md)` will be transformed as `docs/Reference/ngLib/overview`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
