### PR TITLE
docs: update scully serve command and ScullyRoute interface

### DIFF
--- a/docs/learn/create-a-blog/generate-new-blog-posts.md
+++ b/docs/learn/create-a-blog/generate-new-blog-posts.md
@@ -89,7 +89,7 @@ The property `slugs` have been added to the frontmatter above. `slugs` contains 
 Now that page and the route has been generated, let's serve up the application and ensure it works. Type the following command to serve the static site built by Scully:
 
 ```bash
-npm run scully serve
+npm run scully:serve
 ```
 
 The command will give an output looking like so:
@@ -144,7 +144,7 @@ This time around it will render a different route. By default Scully will create
 Let's serve this up with the command:
 
 ```bash
-npm run scully serve
+npm run scully:serve
 ```
 
 Open up your browser and navigate to the URL `http://localhost:1668/blog/angular-tutorial`.
@@ -175,7 +175,7 @@ Note how the `dist/static/blog` folder now has a new entry, namely `angular-js-s
 Serving up the static app with:
 
 ```bash
-npm run scully serve
+npm run scully:serve
 ```
 
 The blog post can now be found at `http://localhost:1668/blog/angularjs-still-rocks`.

--- a/docs/learn/create-a-blog/generate-new-blog-posts_es.md
+++ b/docs/learn/create-a-blog/generate-new-blog-posts_es.md
@@ -89,7 +89,7 @@ La propiedad `slugs` ha sido incluida en la portada del archivo. `slugs` contien
 Ahora que la página y la ruta han sido generadas, ejecutemos el servidor de la aplicación y aseguremos que funciona. Ejecuta el siguiente comando para ejecutar el servidor con el sitio estático creado por Scully:
 
 ```bash
-npm run scully serve
+npm run scully:serve
 ```
 
 El comando dará una salida como esta:
@@ -144,7 +144,7 @@ En este momento será creada una nueva ruta diferente. Por defecto, Scully crear
 Ejecutemos el servidor de scully de nuevo con el comando:
 
 ```bash
-npm run scully serve
+npm run scully:serve
 ```
 
 Abre el navegador y dirigete a la URL `http://localhost:1668/blog/angular-tutorial`.
@@ -175,7 +175,7 @@ Nota ahora que la carpeta `dist/static/blog` ahora tiene un nuevo archivo, ubica
 Ejecutemos el servidor de scully nuevamente con el comando:
 
 ```bash
-npm run scully serve
+npm run scully:serve
 ```
 
 El artículo del post ahora puede encontrarse en la URL `http://localhost:1668/blog/angularjs-still-rocks`.

--- a/docs/learn/create-a-blog/use-blog-post-data-in-template.md
+++ b/docs/learn/create-a-blog/use-blog-post-data-in-template.md
@@ -41,6 +41,7 @@ export interface ScullyRoute {
   published?: boolean;
   slug?: string;
   sourceFile?: string;
+  lang?: string;
   [prop: string]: any;
 }
 ```

--- a/docs/learn/create-a-blog/use-blog-post-data-in-template_es.md
+++ b/docs/learn/create-a-blog/use-blog-post-data-in-template_es.md
@@ -41,6 +41,7 @@ export interface ScullyRoute {
   published?: boolean;
   slug?: string;
   sourceFile?: string;
+  lang?: string;
   [prop: string]: any;
 }
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

- In [Generating new blog posts](https://scully.io/docs/learn/create-a-blog/generate-new-blog-posts/) document scully serve command is specified as `npm run scully serve`, though this will work, but when we add scully in angular project we already provide `"scully:serve": "scully serve"` script in `package.json`, So instead of `npm run scully serve` command it should be the provided script command: `npm run scully:serve`.

- `ScullyRoute` interface now includes `lang` property, but In [Using blog data in an Angular template](https://scully.io/docs/learn/create-a-blog/use-blog-post-data-in-template/) document it is not specified.

Issue Number: N/A

## What is the new behavior?

- Updated scully serve command to `npm run scully:serve`
- Added `lang?:string` property in `ScullyRoute` interface

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
