### PR TITLE
fix(scully): strip string styling escape characters when logging

### DIFF
--- a/libs/scully/src/lib/utils/log.ts
+++ b/libs/scully/src/lib/utils/log.ts
@@ -24,7 +24,10 @@ export enum LogSeveritys {
 export type LogSeverity = 'normal' | 'warning' | 'error' | 'none';
 
 const logFilePath = join(findAngularJsonPath(), 'scully.log');
-const logToFile = (string) => new Promise((res, rej) => appendFile(logFilePath, string, (e) => (e ? rej(e) : res())));
+/** Chalk adds ANSI escape codes for terminal string styling that shouldn't be included in logs  */
+const stripANSICodes = (string) => string.replace(/\x1b\[\d+m/g, '');
+const logToFile = (string) =>
+  new Promise((res, rej) => appendFile(logFilePath, stripANSICodes(string), (e) => (e ? rej(e) : res())));
 
 function* spinTokens() {
   const tokens = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];


### PR DESCRIPTION
No longer log ANSI escape codes from terminal styling to scully.log file

Issue #1010

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

See [issue](https://github.com/scullyio/scully/issues/1010) "ANSI escape codes from terminal styling logged to scully.log file"

Issue Number: 1010

## What is the new behavior?

ANSI escape characters are removed from strings before getting logged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
