### PR TITLE
fix(scully): fix cli options showGuessError and path configuration

### DIFF
--- a/libs/scully/src/lib/utils/cli-options.ts
+++ b/libs/scully/src/lib/utils/cli-options.ts
@@ -84,7 +84,6 @@ export const {
     /** path */
     .string('path')
     .default('path', undefined)
-    .alias('p', 'path')
     .describe('path', 'The path to generate')
     /** port */
     .number('port')
@@ -102,7 +101,7 @@ export const {
     /** showGuessErrors */
     .boolean('sge')
     .alias('sge', 'showGuessError')
-    .describe('sb', 'dumps the error from guess to the console')
+    .describe('sge', 'dumps the error from guess to the console')
 
     .string('cf')
     .alias('cf', 'configFile')


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

- `showGuessError` command description is mapped with `sb` (showBrowser)
- Alias `p` is mapped with two commands `path` and `port`.

Issue Number: N/A

## What is the new behavior?

- `showGuessError` description mapping is fixed.
- Alias `p` removed from `path`. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
