### PR TITLE
fix: scully docs toc overflow issue

### DIFF
--- a/apps/scully-docs/src/styles/toc.css
+++ b/apps/scully-docs/src/styles/toc.css
@@ -7,7 +7,8 @@
   list-style: none;
   border-left: solid 1px rgba(223, 226, 229, 0.8);
   background-color: rgba(0, 0, 0, 0.01);
-  overflow: hidden;
+  overflow: auto;
+  max-height: calc(100% - 110px);
 }
 
 #toc-doc a {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The table of content is not properly rendered on a large list of headings. as shown below 
Affected pages : [Command Line Options](https://scully.io/docs/Reference/command-line-options/) and [Scully Config](https://scully.io/docs/Reference/config/).

![image](https://user-images.githubusercontent.com/34959339/95080157-4b204800-0735-11eb-8a2d-a04e9fd55ea9.png)

Issue Number: N/A

## What is the new behavior?

Updated CSS of TOC. It will now show a scroll bar for a large list.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
