### PR TITLE
feat(scully): give error if start environment is off

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,8 +76,21 @@ To correct this, add the `skipLibCheck` and `skipDefaultLibCheck` flags to your 
 
 > Running scully gives a fatal error: `Unknown type "myPlugin" in route "/aRoute"`
 
-This might happen if you have installed Scully globally, and you are trying to run with the global version.
-Make sure you run scully from the local repo.
+> I get this error:
+
+```
+--------------------------------------------------------------------------
+you started scully outside of a scully project-folder,
+or didn't install packages in this folder.
+We can't find your local copy to start.
+This can also happen on windows with PowerShell and mixed case path-names
+--------------------------------------------------------------------------
+```
+
+This might happen when you started scully from within a different project, a subfolder that is too deeply nested.
+Or you are on Windows, using Powershell and have a uppercase character in your path.
+Scully will first try to start the local version, but if it can't find that, it errors out with this error.
+The solution is that you should start Scully inside the root of your project with:
 
 ```bash
 npm run scully

--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -3,7 +3,7 @@
 /**
  * The above line is needed to be able to run in npx and CI.
  */
-import { readFileSync } from 'fs-extra';
+import { existsSync, readFileSync } from 'fs-extra';
 import open from 'open';
 import { join } from 'path';
 import './lib/pluginManagement/systemPlugins';
@@ -31,14 +31,21 @@ if (process.argv.includes('version')) {
   process.exit(0);
 }
 
-if (process.argv.includes('test')) {
-  console.log('starting from', __dirname);
-  if (!__dirname.includes(process.cwd())) {
-    // const { execSync } = require('child_process');
+if (!__dirname.includes(process.cwd())) {
+  /** started from outside project folder, _or_ powershell with uppercase pathname */
+  if (existsSync('./node_modules/@scullyio/scully/scully.js')) {
     execSync('node ./node_modules/@scullyio/scully/scully.js', {
       cwd: './',
       stdio: 'inherit',
     });
+  } else {
+    logError(`
+--------------------------------------------------------------------------
+you started scully outside of a scully project-folder,
+or didn't install packages in this folder.
+We can't find your local copy to start.
+This can also happen on windows with PowerShell and mixed case path-names
+--------------------------------------------------------------------------`);
   }
   process.exit(0);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Scully fails with a strange error when used in Windows PowerShell on a path that has uppercase characters in it
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #1000 

## What is the new behavior?
It tries to start a local instance, and errors out when that fails. 
So most of the time it will still work.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
