### PR TITLE
docs: remove cli options highlight flag doc

### DIFF
--- a/docs/Reference/command-line-options.md
+++ b/docs/Reference/command-line-options.md
@@ -118,23 +118,6 @@ npx scully serve/watch --ssl --ssl-key=./url/to/file
 
 Adds a url to an ssl key file for a server with SSL.
 
-#### highlight
-
-```bash
-npx scully serve/watch --hl
-```
-
-Add highlight.js to render into the markdown's files.
-
-If you use this flag, you need to add the css into the index.html:
-
-```html
-<link
-  rel="stylesheet"
-  href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
-/>
-```
-
 #### tds
 
 ```bash


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

[Command Line Options](https://scully.io/docs/Reference/command-line-options/) doc includes the `highlight` flag, which is not used anywhere in code.
Scully uses `prism.js` and `md` plugin to render code snippets. `highlight.js` and `highlight` flag is not in use, the `highlight` flag might misguide the user.

Issue Number: N/A

## What is the new behavior?

Removed the highlight flag doc.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
