### PR TITLE
refactor(lib): use camel case for copyToClipboard plugin

### DIFF
--- a/libs/plugins/scully-plugin-copy-to-clipboard/README.md
+++ b/libs/plugins/scully-plugin-copy-to-clipboard/README.md
@@ -10,12 +10,12 @@ Render Plugin
 
 1. This plugin requires the `clipboard.min.js`. Download it from [here](https://clipboardjs.com/) and add it in `assets` folder of your application.
 
-2. In the application's `scully.<your-app>.config.ts`, Import `CopyToClipboard` plugin and add it in `defaultPostHandlers`.
+2. In the application's `scully.<your-app>.config.ts`, Import `copyToClipboard` plugin and add it in `defaultPostHandlers`.
 
 ```typescript
-import { CopyToClipboard } from '@scullyio/scully-plugin-copy-to-clipboard';
+import { copyToClipboard } from '@scullyio/scully-plugin-copy-to-clipboard';
 
-const defaultPostRenderers = [CopyToClipboard];
+const defaultPostRenderers = [copyToClipboard];
 
 export const config: ScullyConfig = {
   defaultPostRenderers,
@@ -37,7 +37,7 @@ export const config: ScullyConfig = {
 Provide custom plugin configuration in application's `scully.<your-app>.config.ts`.
 
 ```typescript
-setPluginConfig<CopyToClipboardPluginConfig>(CopyToClipboard, {
+setPluginConfig<CopyToClipboardPluginConfig>(copyToClipboard, {
   copyBtnInitialText: '📄',
   copyBtnOnClickText: '✅',
   customBtnClass: 'customClass',

--- a/libs/plugins/scully-plugin-copy-to-clipboard/src/lib/plugins-scully-plugin-copy-to-clipboard.spec.ts
+++ b/libs/plugins/scully-plugin-copy-to-clipboard/src/lib/plugins-scully-plugin-copy-to-clipboard.spec.ts
@@ -1,7 +1,7 @@
-import { CopyToClipboard } from './plugins-scully-plugin-copy-to-clipboard';
+import { copyToClipboard } from './plugins-scully-plugin-copy-to-clipboard';
 
 describe('ScullyPluginCopyToClipboard', () => {
   it('should work', () => {
-    expect(CopyToClipboard).toEqual('CopyToClipboard');
+    expect(copyToClipboard).toEqual('copyToClipboard');
   });
 });

--- a/libs/plugins/scully-plugin-copy-to-clipboard/src/lib/plugins-scully-plugin-copy-to-clipboard.ts
+++ b/libs/plugins/scully-plugin-copy-to-clipboard/src/lib/plugins-scully-plugin-copy-to-clipboard.ts
@@ -1,7 +1,7 @@
 import { registerPlugin, getPluginConfig, logWarn, yellow, HandledRoute } from '@scullyio/scully';
 import { JSDOM } from 'jsdom';
 
-export const CopyToClipboard = 'CopyToClipboard';
+export const copyToClipboard = 'copyToClipboard';
 
 export interface CopyToClipboardPluginConfig {
   /** add custom css class for copy button to apply styles */
@@ -25,7 +25,7 @@ const defaultConfig: CopyToClipboardPluginConfig = {
 };
 
 const copyToClipboardPlugin = async (html: string, options: HandledRoute): Promise<string> => {
-  const pluginConfig = { ...defaultConfig, ...getPluginConfig<CopyToClipboardPluginConfig>(CopyToClipboard) };
+  const pluginConfig = { ...defaultConfig, ...getPluginConfig<CopyToClipboardPluginConfig>(copyToClipboard) };
 
   try {
     const dom = new JSDOM(html);
@@ -110,7 +110,7 @@ const copyToClipboardPlugin = async (html: string, options: HandledRoute): Promi
     document.body.appendChild(styleEl);
     return dom.serialize();
   } catch (e) {
-    logWarn(`error in ${CopyToClipboard} Plugin, didn't parse for route "${yellow(options.route)}"`, e);
+    logWarn(`error in ${copyToClipboard} Plugin, didn't parse for route "${yellow(options.route)}"`, e);
   }
 
   return html;
@@ -118,4 +118,4 @@ const copyToClipboardPlugin = async (html: string, options: HandledRoute): Promi
 
 const validator = async () => [];
 
-registerPlugin('render', CopyToClipboard, copyToClipboardPlugin, validator);
+registerPlugin('render', copyToClipboard, copyToClipboardPlugin, validator);

--- a/scully.scully-docs.config.ts
+++ b/scully.scully-docs.config.ts
@@ -3,7 +3,7 @@ import { docLink } from '@scullyio/scully-plugin-docs-link-update';
 import { GoogleAnalytics } from '@scullyio/scully-plugin-google-analytics';
 import { LogRocket } from '@scullyio/scully-plugin-logrocket';
 import { Sentry } from '@scullyio/scully-plugin-sentry';
-import { CopyToClipboard } from '@scullyio/scully-plugin-copy-to-clipboard';
+import { copyToClipboard } from '@scullyio/scully-plugin-copy-to-clipboard';
 import { removeScripts, RemoveScriptsConfig } from '@scullyio/scully-plugin-remove-scripts';
 const marked = require('marked');
 import { readFileSync } from 'fs-extra';
@@ -17,7 +17,7 @@ const { document } = window;
 
 setPluginConfig('md', { enableSyntaxHighlighting: true });
 
-const defaultPostRenderers = [LogRocket, GoogleAnalytics, removeScripts, 'seoHrefOptimise', criticalCSS, CopyToClipboard];
+const defaultPostRenderers = [LogRocket, GoogleAnalytics, removeScripts, 'seoHrefOptimise', criticalCSS, copyToClipboard];
 
 if (prod) {
   /*


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: Rename the name of the plugin `CopyToClipboard` → `copyToClipboard`

## What is the current behavior?
It is PascalCase.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
It should be camelCase to keep consistency.

## Does this PR introduce a breaking change?

- [x] Yes, because the variable has changed from PascalCase to camelCase .
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
