### PR TITLE
docs(scully): Add config function to the router plugin example

### DIFF
--- a/docs/Reference/plugins/types/router.md
+++ b/docs/Reference/plugins/types/router.md
@@ -42,6 +42,7 @@ function userIdPlugin(route: string, config = {}): Promise<HandledRoute[]> {
   ]);
 }
 
+const validator = async (conf) => [];
 registerPlugin('router', 'userIds', userIdPlugin, validator);
 ```
 


### PR DESCRIPTION
In the example the config function is missing causing the plugin
to be invalid

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe:

Updating documentation 

## What is the current behavior?

In the documentation for a router plugin, the config function its not declared. And its 

Issue Number: N/A

## What is the new behavior?

Added the config function to the example

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
