### PR TITLE
feat(monorepo): feat(critical) expose ignore settings in plugin configuration

### DIFF
--- a/libs/plugins/scully-plugin-critical-css/README.md
+++ b/libs/plugins/scully-plugin-critical-css/README.md
@@ -77,6 +77,12 @@ export interface CriticalCSSSettings {
   }[];
   /** An array with fully qualified paths to assets, if none is given, the root, and the root/assets will be used to look for static assets*/
   assets?: string[];
+  /** Ignore some css rules */
+  ignore?: {
+    atrule?: string[];
+    rule?: string[];
+    decl?: (node, value) => boolean;
+  };
 }
 ```
 

--- a/libs/plugins/scully-plugin-critical-css/src/lib/plugins-scully-plugin-critical-css.ts
+++ b/libs/plugins/scully-plugin-critical-css/src/lib/plugins-scully-plugin-critical-css.ts
@@ -19,6 +19,12 @@ export interface CriticalCSSSettings {
   }[];
   /** An array with fully qualified paths to assets, if none is given, the root, and the root/assets will be used to look for static assets*/
   assets?: string[];
+  /** Ignore some css rules, see https://github.com/addyosmani/critical#critical*/
+  ignore?: {
+    atrule?: string[];
+    rule?: string[];
+    decl?: (node, value) => boolean;
+  };
 }
 
 const defaultSettings: CriticalCSSSettings = {
@@ -55,6 +61,7 @@ const criticalCssPlugin = async (incomingHtml: string, route: HandledRoute) => {
         /** we will minify the inlined css */
         minify: true,
       },
+      ignore: settings.ignore,
     };
     /** dimensions overpower the width/height settings, only set if indees setted. */
     if (settings.dimensions) {


### PR DESCRIPTION
Hi! 

I'm not sure if this is a feature rather than anything else, please let me know if I need to change something.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It's not possible to pass `ignore` configuration to the `critical` tool (see https://github.com/addyosmani/critical#critical)


## What is the new behavior?
ignore configuration is documented in the plugin options interface and is passed to the critical tool
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
