### PR TITLE
fix(scully): fix config parsing when using logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 1. Fork the scullyio/scully repo.
 1. Make your changes in a new git branch:
 
-   ```shell
+   ```bash
    git checkout -b my-fix-branch main
    ```
 
@@ -88,7 +88,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 1. Push your branch to GitHub:
 
-   ```shell
+   ```bash
    git push origin my-fix-branch
    ```
 
@@ -99,7 +99,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
   - Make the required updates.
   - Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
-    ```shell
+    ```bash
     git rebase main -i
     git push -f
     ```
@@ -113,25 +113,25 @@ from the main (upstream) repository:
 
 - Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
 
-  ```shell
+  ```bash
   git push origin --delete my-fix-branch
   ```
 
 - Check out the main branch:
 
-  ```shell
+  ```bash
   git checkout main -f
   ```
 
 - Delete the local branch:
 
-  ```shell
+  ```bash
   git branch -D my-fix-branch
   ```
 
 - Update your main with the latest upstream version:
 
-  ```shell
+  ```bash
   git pull --ff upstream main
   ```
 

--- a/docs/Reference/command-line-options.md
+++ b/docs/Reference/command-line-options.md
@@ -147,7 +147,7 @@ If you do not use the flag (true by default) when you have an error in any plugi
 
 #### logSeverity
 
-Overrides the logSeverity from the config file
+Sets the log severity option. Defaults to 'warning'
 
 ```bash
 npx scully --logSeverity=none

--- a/docs/Reference/config.md
+++ b/docs/Reference/config.md
@@ -45,8 +45,6 @@ export interface ScullyConfig {
   hostFolder?: string;
   /** transferState only inlined into page, and not written into separate data.json */
   inlineStateOnly?: boolean;
-  /** Set what is what is written to the logfile, defaults to warnings and errors */
-  logFileSeverity?: LogSeverity;
   /** routes that need additional processing have their configuration in here */
   routes: RouteConfig;
   /** routes that are in the application but have no route in the router */
@@ -97,7 +95,7 @@ The folder's path where Scully leaves the statics files.
 This should not be the same as the `distFolder`.  
 The default path is:
 
-```URL
+```
 ./dist/static
 ```
 
@@ -106,18 +104,6 @@ The default path is:
 Path to the Angular application's dist folder.  
 Scully takes the `angular.json` file's default path and will use this folder during rendering.  
 This option can be modified according to your needs.
-
-#### logFileSeverity
-
-Determines what of the Scully output will be written into the `scully.log` file in the root of the project.
-Due to the fact that this option is _in_ the config, the default `warning` setting will be used until the config is fully processed. If there are errors and/or warnings raised during the processing of the config, those _will_ be logged. You can override this behavior by using the `--logSeverity` command line parameter.
-
-| option    | result                                  |
-| --------- | --------------------------------------- |
-| `normal`  | Logs everything                         |
-| `warning` | Logs warnings and errors only           |
-| `error`   | Logs only errors                        |
-| `none`    | Logs nothing, after config is processed |
 
 #### routes
 

--- a/docs/Reference/config_es.md
+++ b/docs/Reference/config_es.md
@@ -45,8 +45,6 @@ export interface ScullyConfig {
   hostFolder?: string;
   /** transferState only inlined into page, and not written into separate data.json */
   inlineStateOnly?: boolean;
-  /** Set what is what is written to the logfile, defaults to warnings and errors */
-  logFileSeverity?: LogSeverity;
   /** routes that need additional processing have their configuration in here */
   routes: RouteConfig;
   /** routes that are in the application but have no route in the router */
@@ -97,7 +95,7 @@ La ubicación de la carpeta donde Scully dejará los archivos estáticos.
 No debe ser igual al utilizado en `distFolder`.
 Por defecto es:
 
-```URL
+```
 ./dist/static
 ```
 
@@ -106,18 +104,6 @@ Por defecto es:
 Ubicación a la carpeta dist de la aplicación Angular.
 Scully toma la ubicación del archivo `angular.json` y la usará esta carpeta para el renderizado.
 Esta opción puede ser modificada a tus necesidades.
-
-#### logFileSeverity
-
-Determina cuáles de las salidas de Scully será escritas dentro del archivo `scully.log` en la raíz del proyecto.
-Debido a que esta opción se encuentra _dentro_ de la configuración, por defecto se usará el valor `warning` hasta que la configuración se haya procesado por completo. Si existen errores o advertencias durante el procesamiento de la de configuración, _serán_ guardadas en el archivo. Puedes sobreescribir esta características usando el parámetro `--logSeverity` desde la línea de comandos.
-
-| opción    | resultado                                   |
-| --------- | ------------------------------------------- |
-| `normal`  | tood                                        |
-| `warning` | Sólo advertencias y errores                 |
-| `error`   | Sólo errors                                 |
-| `none`    | Nada pero se creará un archivo `scully.log` |
 
 #### routes
 

--- a/docs/Reference/plugins/community-plugins/minifyHtml.md
+++ b/docs/Reference/plugins/community-plugins/minifyHtml.md
@@ -69,7 +69,7 @@ exports.config = {
 
 Now build your app and then just run the Scully command.
 
-```shell script
+```bash
 npm run build --prod
 npm run scully
 ```

--- a/docs/Reference/plugins/community-plugins/minifyHtml_es.md
+++ b/docs/Reference/plugins/community-plugins/minifyHtml_es.md
@@ -34,9 +34,9 @@ Este paquete depende del paquete [`html-minifier`](https://www.npmjs.com/package
 
 ## Uso9
 
-Importa y agrega el complemento a `defaultPostRenderers` para que ejecute sobre todas las páginas renderizadas o utiliza `postRenderers` en cada ruta. 
+Importa y agrega el complemento a `defaultPostRenderers` para que ejecute sobre todas las páginas renderizadas o utiliza `postRenderers` en cada ruta.
 
-**Importante:**  la actual configuración de Scully dice que si utilizas la opción `postRenderers` sobre una ruta, ignorará la configuración global en `defaultPostRenderers`.
+**Importante:** la actual configuración de Scully dice que si utilizas la opción `postRenderers` sobre una ruta, ignorará la configuración global en `defaultPostRenderers`.
 
 Para más información, visita: https://github.com/scullyio/scully/issues/595
 
@@ -63,7 +63,7 @@ exports.config = {
 
 Compila la aplicación y luego sólo debes ejecutar el comando de Scully.
 
-```shell script
+```bash
 npm run build --prod
 npm run scully
 ```
@@ -102,6 +102,7 @@ const defaultMinifyOptions: Options = {
   ignoreCustomFragments: [/\/\*\* ___SCULLY_STATE_(START|END)___ \*\//],
 };
 ```
+
 Para configurar las opciones se puede hacer con la función `setPluginConfig`.
 Puedes especificar un subconjunto de opciones que sobre-escribirán la configuración por defecto.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,7 +189,7 @@ A lot of information about this is on the [puppeteet troubleshooting page](https
 
 We heard back from several users that a dockerfile like the below one works for them.
 
-```Dockerfile
+```docker
 FROM node:12-alpine
 
 RUN apk add --no-cache \
@@ -202,7 +202,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 As a base docker config, and then make sure to set the environment correctly in the container that runs Scully:
 In order to use this I create my projects' Docker file like this:
 
-```Dockerfile
+```docker
 FROM aboveConfig
 ENV SCULLY_PUPPETEER_EXECUTABLE_PATH '/usr/bin/chromium-browser'
 ... more docker stuff here

--- a/docs/faq_es.md
+++ b/docs/faq_es.md
@@ -77,7 +77,7 @@ Para corregir esto, agrega las propiedades `skipLibCheck` y `skipDefaultLibCheck
 > Ejecutar Scully devuelve el error: `Unknown type "myPlugin" in route "/aRoute"`
 
 Esto podria pasar si tienes instalado Scully globalmente, y tu estás tratando de ejecutar con la versión global.
-Áseguresé que  está ejecutando Scully desde su repositorio local.
+Áseguresé que está ejecutando Scully desde su repositorio local.
 
 ```bash
 npm run scully
@@ -176,7 +176,7 @@ Hay mucha información sobre esto en la [página de solución de problemas de pu
 
 Varios usuarios nos comentaron que con la siguiente configuración funciona para ellos.
 
-```Dockerfile
+```docker
 FROM node:12-alpine
 
 RUN apk add --no-cache \
@@ -189,7 +189,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 Utiliza esta configuración básica de Docker, y luego asegúrese de configurar el entorno correctamente en el contenedor que ejecuta Scully:
 Para usar esto, creamos los proyectos Docker con una configuración como esta:
 
-```Dockerfile
+```docker
 FROM aboveConfig
 ENV SCULLY_PUPPETEER_EXECUTABLE_PATH '/usr/bin/chromium-browser'
 ... more docker stuff here

--- a/docs/learn/create-a-blog/add-blog-support.md
+++ b/docs/learn/create-a-blog/add-blog-support.md
@@ -42,7 +42,7 @@ You will be prompted with the following questions:
 
 After adding the blog support, you should see the following message:
 
-```output
+```bash
     ✅️ Update scully.{{yourApp}}.config.js
 UPDATE scully.{{yourApp}}.config.js (653 bytes)
 UPDATE src/app/app-routing.module.ts (726 bytes)

--- a/docs/learn/create-a-blog/add-blog-support_es.md
+++ b/docs/learn/create-a-blog/add-blog-support_es.md
@@ -42,7 +42,7 @@ Este comando presentará las siguientes preguntas:
 
 Después de agregar el soporte para blog, se visualiza ver el siguiente mensaje:
 
-```output
+```bash
     ✅️ Update scully.{{yourApp}}.config.js
 UPDATE scully.{{yourApp}}.config.js (653 bytes)
 UPDATE src/app/app-routing.module.ts (726 bytes)

--- a/docs/learn/create-a-blog/generate-new-blog-posts.md
+++ b/docs/learn/create-a-blog/generate-new-blog-posts.md
@@ -27,7 +27,7 @@ ng generate @scullyio/init:post --name="This is my post"
 
 Let's look at an example. We want to create a new blog post so we type the following in the terminal `ng generate @scullyio/init:post --name="Angular tutorial"`. This triggers the following output:
 
-```output
+```bash
 ng generate @scullyio/init:post --name="Angular tutorial"
 ? What's the target folder for this post? blog
     ✅️ Blog ./blog/angular-tutorial.md file created
@@ -36,7 +36,7 @@ CREATE blog/angular-tutorial.md (99 bytes)
 
 Above you are prompted where you want to place your blog post. You go with default, which is the `blog/` directory. You can then see above how the file `angular-tutorial.md` is created with this message:
 
-```output
+```bash
 CREATE blog/angular-tutorial.md
 ```
 
@@ -94,7 +94,7 @@ npm run scully:serve
 
 The command will give an output looking like so:
 
-```output
+```bash
 Angular distribution server started on "http://localhost:1864/"
 Scully static server started on "http://localhost:1668/"
 ```

--- a/docs/learn/create-a-blog/generate-new-blog-posts_es.md
+++ b/docs/learn/create-a-blog/generate-new-blog-posts_es.md
@@ -27,7 +27,7 @@ ng generate @scullyio/init:post --name="This is my post"
 
 Veamos un ejemplo. Si queremos crear un nuevo artículo para el blog entonces escribimos el siguiente comando en la consola `ng generate @scullyio/init:post --name="Angular tutorial"`. Esto mostrará el siguiente mensaje:
 
-```output
+```bash
 ng generate @scullyio/init:post --name="Angular tutorial"
 ? What's the target folder for this post? blog
     ✅️ Blog ./blog/angular-tutorial.md file created
@@ -36,7 +36,7 @@ CREATE blog/angular-tutorial.md (99 bytes)
 
 El comando de arriba preguntará dónde quieres colocar el artículo. Seleccionamos el valor por defecto, que es en la carpeta `blog/`. Podemos ver a continuación como el archivo `angular-tutorial.md` es creado y muestra el siguiente mensaje:
 
-```output
+```bash
 CREATE blog/angular-tutorial.md
 ```
 
@@ -94,7 +94,7 @@ npm run scully:serve
 
 El comando dará una salida como esta:
 
-```output
+```bash
 Angular distribution server started on "http://localhost:1864/"
 Scully static server started on "http://localhost:1668/"
 ```

--- a/libs/scully/package.json
+++ b/libs/scully/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Scully CLI",
   "repository": {
     "type": "GIT",

--- a/libs/scully/src/lib/fileHanderPlugins/markdown.ts
+++ b/libs/scully/src/lib/fileHanderPlugins/markdown.ts
@@ -15,6 +15,7 @@ import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-docker';
 
 const renderer = new marked.Renderer();
 // wrap code block the way Prism.js expects it

--- a/libs/scully/src/lib/utils/cli-options.ts
+++ b/libs/scully/src/lib/utils/cli-options.ts
@@ -174,7 +174,11 @@ export const {
     .alias('prod', 'Production')
     .default('prod', false)
     .describe('prod', 'Use prod mode for Scully')
+    /** logSeverity */
     .choices('logSeverity', ['normal', 'warning', 'error', 'none'])
+    .alias('logSeverity', 'ls')
+    .alias('logSeverity', 'log-severity')
+    .default('logSeverity', 'warning')
     .describe('logSeverity', 'select the log-severity level').argv;
 
 yargs.help();

--- a/libs/scully/src/lib/utils/config.ts
+++ b/libs/scully/src/lib/utils/config.ts
@@ -14,7 +14,6 @@ export const scullyDefaults: Partial<ScullyConfig> = {
   bareProject: false,
   homeFolder: angularRoot,
   outDir: join(angularRoot, './dist/static/'),
-  logFileSeverity: 'warning',
   inlineStateOnly: false,
   thumbnails: false,
   maxRenderThreads: cpus().length,

--- a/libs/scully/src/lib/utils/interfacesandenums.ts
+++ b/libs/scully/src/lib/utils/interfacesandenums.ts
@@ -30,8 +30,6 @@ export interface ScullyConfig {
   hostFolder?: string;
   /** transferState only inlined into page, and not written into separate data.json */
   inlineStateOnly?: boolean;
-  /** Set what is what is written to the logfile, defaults to warnings and errors */
-  logFileSeverity?: LogSeverity;
   /** routes that need additional processing have their configuration in here */
   routes: RouteConfig;
   /** routes that are in the application but have no route in the router */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
When you use/import one of the log functions Scully starts to process the config file.
This makes it hard to write tests and is unneeded when just importing.
Also, an empty log file is created when log-severity none is given. (#1119) 
and a couple of warnings are raised because of misaligned 'prism' types

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #1119

## What is the new behavior?
The logServirity config file option is removed(breaking change). Now it's only possible to set this option using the cmd-line.
Also, markdown files using 'prism' languages that are non-existent are updated, and if available the corresponding prism components are loaded.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The impact of the breaking change is very low, as the functionality is still there. As we need to be able to start logging _before_ we can process the config file, the log-level can't be determined by the config file, as that would inflict issues as this PR solves


## Other information
