### PR TITLE
fix(scully): refactor to allow Scully to exit a process in library mode.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,13 @@
 {
   "configurations": [
     {
+      "name": "testexit",
+      "program": "${workspaceFolder}/testexit.js",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
       "name": "Launch via NPM",
       "type": "node",
       "request": "launch",

--- a/libs/scully/package.json
+++ b/libs/scully/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scullyio/scully",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Scully CLI",
   "repository": {
     "type": "GIT",

--- a/libs/scully/src/lib/startBackgroundServer.ts
+++ b/libs/scully/src/lib/startBackgroundServer.ts
@@ -1,12 +1,10 @@
 import { spawn } from 'child_process';
 import { existsSync } from 'fs-extra';
 import { join } from 'path';
-import { tds, watch, configFileName, pjFirst, handle404 } from './utils/cli-options';
-import { ScullyConfig } from './utils/interfacesandenums';
-import { green, log, logError, logWarn } from './utils/log';
 import { captureMessage } from './utils/captureMessage';
-import yargs from 'yargs';
-import { handleTravesal } from '..';
+import { configFileName, handle404, logSeverity, pjFirst, tds, port } from './utils/cli-options';
+import { ScullyConfig } from './utils/interfacesandenums';
+import { green, log, logError } from './utils/log';
 
 const baseBinary = __dirname + '/scully.js';
 
@@ -22,7 +20,7 @@ export function startBackgroundServer(scullyConfig: ScullyConfig) {
     process.exit(15);
     return;
   }
-  const options = [binary, `serve`, '--tds', tds ? 'true' : 'false', '--pjf', pjFirst ? 'true' : 'false'];
+  const options = [binary, `serve`, '--tds', tds ? 'true' : 'false', '--pjf', pjFirst ? 'true' : 'false', '--ls', logSeverity];
   if (configFileName) {
     options.push('--cf');
     options.push(configFileName);
@@ -33,6 +31,10 @@ export function startBackgroundServer(scullyConfig: ScullyConfig) {
   if (handle404) {
     options.push('--404');
     options.push(handle404);
+  }
+  if (port) {
+    options.push('--port');
+    options.push(String(port));
   }
   spawn(
     'node',

--- a/libs/scully/src/lib/utils/cli-options.ts
+++ b/libs/scully/src/lib/utils/cli-options.ts
@@ -183,7 +183,7 @@ export const {
 
 yargs.help();
 
-const commandsArray = yargs.argv._.map((c) => c.toLowerCase().trim());
+const commandsArray = yargs.argv._.filter((c) => typeof c === 'string').map((c) => c.toLowerCase().trim());
 
 export const serve = commandsArray.includes('serve');
 export const killServer = commandsArray.includes('killserver');

--- a/libs/scully/src/lib/utils/exitHandler.ts
+++ b/libs/scully/src/lib/utils/exitHandler.ts
@@ -1,31 +1,42 @@
 import { browser } from '../renderPlugins/launchedBrowser';
-/**
- * The following code is to make sure puppeteer will be closed properly.
- * Future additions on cleanup might to be handled here too.
- */
-process.stdin.resume(); // so the program will not close instantly
 
-function exitHandler(options, exitCode) {
-  if (options.cleanup && browser) {
-    browser.close();
-  }
-  if (exitCode || exitCode === 0) {
-    if (typeof exitCode !== 'number') {
-      /** not a 'clean' exit log to console */
-      console.log(exitCode);
+export function installExitHandler() {
+  /**
+   * The following code is to make sure puppeteer will be closed properly.
+   * Future additions on cleanup might to be handled here too.
+   */
+
+  /**
+   * We need this because we want to handle the exception codes.
+   * However, If this is in place, node will _not_ exit anymore when the event cue runs to its end.
+   * so this is inside a function, we must call when we need this. We can _not_ do it when we are in 'library' mode.
+   * without it, we have no proper way to wind down the browser or puppeteer.
+   */
+  process.stdin.resume(); // so the program will not close.
+
+  function exitHandler(options, exitCode) {
+    if (options.cleanup && browser) {
+      browser.close().then(() => process.exit(0));
+    }
+    if (exitCode || exitCode === 0) {
+      if (typeof exitCode !== 'number') {
+        /** not a 'clean' exit log to console */
+        console.log(exitCode);
+      }
+    }
+    // TODO: kill the server here. (but only if started from scully, not when started from another process)
+    if (options.exit) {
+      process.exit();
     }
   }
-  // TODO: kill the server here. (but only if started from scully, not when started from another process)
-  if (options.exit) {
-    process.exit();
-  }
+  // do something when app is closing
+  process.on('exit', exitHandler.bind(null, { cleanup: true }));
+  // catches ctrl+c event
+  process.on('SIGINT', exitHandler.bind(null, { exit: true }));
+  process.on('SIGTERM', exitHandler.bind(null, { exit: true }));
+  // catches "kill pid" (for example: nodemon restart)
+  process.on('SIGUSR1', exitHandler.bind(null, { exit: true }));
+  process.on('SIGUSR2', exitHandler.bind(null, { exit: true }));
+  // catches uncaught exceptions
+  process.on('uncaughtException', exitHandler.bind(null, { exit: true }));
 }
-// do something when app is closing
-process.on('exit', exitHandler.bind(null, { cleanup: true }));
-// catches ctrl+c event
-process.on('SIGINT', exitHandler.bind(null, { exit: true }));
-// catches "kill pid" (for example: nodemon restart)
-process.on('SIGUSR1', exitHandler.bind(null, { exit: true }));
-process.on('SIGUSR2', exitHandler.bind(null, { exit: true }));
-// catches uncaught exceptions
-process.on('uncaughtException', exitHandler.bind(null, { exit: true }));

--- a/libs/scully/src/lib/utils/log.ts
+++ b/libs/scully/src/lib/utils/log.ts
@@ -65,7 +65,9 @@ function writeProgress(msg = state.lastMessage) {
     }
     readline.clearLine(process.stdout, 0);
     readline.cursorTo(process.stdout, 0, null);
-    process.stdout.write(`${state.lastSpin} ${msg}`);
+    if (msg) {
+      process.stdout.write(`${state.lastSpin} ${msg}`);
+    }
     state.lastMessage = msg;
   }
 }
@@ -115,7 +117,10 @@ function enhancedLog(colorFn, severity: LogSeveritys, ...args: any[]) {
     captureMessage(out.filter((i) => i).join('\r\n'));
   }
   // tslint:disable-next-line: no-unused-expression
-  process.stdout.cursorTo && process.stdout.cursorTo(0);
+  if (process.stdout.cursorTo) {
+    process.stdout.cursorTo(0);
+    readline.clearLine(process.stdout, 0);
+  }
   process.stdout.write(colorFn(...out));
   process.stdout.write('\n');
   writeProgress();

--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -3,23 +3,24 @@
 /**
  * The above line is needed to be able to run in npx and CI.
  */
+import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs-extra';
 import open from 'open';
 import { join } from 'path';
 import './lib/pluginManagement/systemPlugins';
 import { startBackgroundServer } from './lib/startBackgroundServer';
 import { ScullyConfig, waitForServerToBeAvailable } from './lib/utils';
+import { captureException } from './lib/utils/captureMessage';
 import { hostName, openNavigator, removeStaticDist, ssl, watch } from './lib/utils/cli-options';
 import { loadConfig, scullyDefaults } from './lib/utils/config';
+import './lib/utils/exitHandler';
+import { installExitHandler } from './lib/utils/exitHandler';
 import { moveDistAngular } from './lib/utils/fsAngular';
 import { httpGetJson } from './lib/utils/httpGetJson';
 import { logError, logWarn, yellow } from './lib/utils/log';
-import { captureException } from './lib/utils/captureMessage';
 import { isPortTaken } from './lib/utils/serverstuff/isPortTaken';
 import { startScully } from './lib/utils/startup';
 import { bootServe, isBuildThere, watchMode } from './lib/watchMode';
-import { execSync } from 'child_process';
-import './lib/utils/exitHandler';
 
 /** the default of 10 is too shallow for generating pages. */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -80,6 +81,7 @@ https://scully.io/docs/learn/getting-started/installation/
 }
 
 (async () => {
+  installExitHandler();
   /** make sure not to do something before the config is ready */
   let scullyConfig: ScullyConfig;
   let err;

--- a/testexit.js
+++ b/testexit.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+/**
+ * The above line is needed to be able to run in npx and CI.
+ */
+const { log, yellow } = require('./dist/libs/scully');
+
+log(`I like ${yellow('yellow')}`);
+log(process.eventNames().join('\n'));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
When you load something out of Scully in library mode (not actually running any of the parts) the calling program will not exit naturally anymore.
Issue Number: N/A

## What is the new behavior?
Node will exit when Scully is used in 'library' mode

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
