### PR TITLE
docs: add time-to-read plugin to the docs

### DIFF
--- a/docs/Reference/plugins/community-plugins/time-to-read.md
+++ b/docs/Reference/plugins/community-plugins/time-to-read.md
@@ -1,0 +1,47 @@
+---
+title: time-to-read Plugin
+published: true
+lang: en
+position: 100
+---
+
+# `⌚ scully-plugin-time-to-read 📖 Plugin
+
+<div class="docs-link_table">
+  <a class="repository" href="https://github.com/Jefiozie/nx-jefiozie/tree/master/libs/time-to-read"></a>
+</div>
+
+
+The `scully-plugin-time-to-read` is a `routeProcess` plugin for [Scully](http://scully.io/) that processes a specific route and will add the 'readingTime' property to the `RouteData. This property reflects the time that people need to read the content.
+
+This plugin is designed (and test) to work with the blog schematic and the contentFolder plugin. 
+
+## 📦 Installation
+
+To install this plugin with `npm` run
+
+```
+$ npm install scully-plugin-time-to-read --save-dev
+```
+
+## Usage
+
+Add the folowing configuration to your scully config: 
+
+```typescript
+// scully.config.ts
+setPluginConfig(timeToRead, {
+  path: '<THE PATH TO YOUR ROUTES>'
+} as timeToReadOptions);
+
+```
+You can now use the `RouteData` and get the `readingTime` property in your component.
+To get the routes you can use the `ScullyRoutesService` and pass the route with data to your component.
+
+Below a example of how you can use the `readingTime` property in your component.
+
+```html
+      <mat-card-subtitle>
+        Date: {{ route?.data?.date | date: 'dd-MM-yyyy' }} - {{ route?.data?.readingTime | number:'1.0-0'}} min read
+      </mat-card-subtitle>
+```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This plugin will add an extra data property that people can use with the blog schematics and will say how much time an article cost to read it.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
