### PR TITLE
feat(scully): throw trapped error if fatal puppeteer error around chomium location

### DIFF
--- a/libs/scully/src/lib/renderPlugins/launchedBrowser.ts
+++ b/libs/scully/src/lib/renderPlugins/launchedBrowser.ts
@@ -85,7 +85,11 @@ function obsBrowser(options: LaunchOptions = scullyConfig.puppeteerLaunchOptions
             return b;
           })
           .catch((e) => {
-            if (++failedLaunces < 3) {
+            if (e.message.includes('Could not find browser revision')) {
+              logError(
+                `Puppeteer cannot find chromium installation.  Try adding 'puppeteerLaunchOptions: {executablePath: CHROMIUM_PATH}' to your scully.*.config.ts file.`
+              );
+            } else if (++failedLaunces < 3) {
               return launches.next();
             }
             captureException(e);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ x ] Bugfix
- [ x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Traps error, calls `return launches.next();` but for this error, won't actually do anything.

Issue Number: N/A

## What is the new behavior?

Logs error to console, for easier debugging of a hung scully build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
