### PR TITLE
Use position absolute to hide

### DIFF
--- a/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
+++ b/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
@@ -104,7 +104,7 @@ async function addBitsToHead(html) {
 	}
 </script>
 <style type="text/css">
-	body:not(.${LoadedClass}) ${AppRootSelector} { display:none; }
+	body:not(.${LoadedClass}) ${AppRootSelector} { position: absolute; }
 	body:not(.${LoadedClass}) ${AppRootSelector}-scully { display:${DisplayType}; }
 	body.${LoadedClass} ${AppRootSelector} { display:${DisplayType}; }
   body.${LoadedClass} ${AppRootSelector}-scully { display:none; }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the app-root is display:none until angular has taken it over and fully hydrated it.
This means that when angular runs initially, it is building something which doesn't take up any space on the page.
This causes issues In some cases, though, where things are positioned with JS based on their sizes etc in the DOM.
For example, angular material with an open side bar: The content (mat-sidenav-content ) is supposed to be given a style attribute (margin-left: 200px) in order that it not be covered by the side bar.
This wasn't happening - the side bar was covering the content intill angular recalculated,either on route change or window resize.

I tried different hacks - triggering a resize event to make angular recalculate, setting the 200px in css (creating the css in the component to ensure that I used the breakpoint, Breakpoints.Handset), but they are less then ideal.

Issue Number: N/A

## What is the new behavior?

In this PR, I "hide" the app-root by giving it a `position: absolute` as long as `body:not(.loaded)`.
It takes up space, but will (by definition - its not going to get bigger then the static markup) be hidden by / underneath the static site, until the static site is hidden/removed.

Potentially, using position:absolute to hide could be part of the config passed in to `getFlashPreventionPlugin`.
Also, I could add `visibility:hidden`, to ensure that even in the odd case where app-root is poking out somewhere, it still won't be seen.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe

It's hard to know for sure if this would break anything... In theory it wouldn't, but browser land is a wild place, so hard to say for sure.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
