### PR TITLE
fix(scully): don't check  if launched from project folder

### DIFF
--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -32,25 +32,6 @@ if (process.argv.includes('version')) {
   process.exit(0);
 }
 
-if (!__dirname.includes(process.cwd())) {
-  /** started from outside project folder, _or_ powershell with uppercase pathname */
-  if (existsSync('./node_modules/@scullyio/scully/scully.js')) {
-    execSync('node ./node_modules/@scullyio/scully/scully.js', {
-      cwd: './',
-      stdio: 'inherit',
-    });
-  } else {
-    logError(`
---------------------------------------------------------------------------
-you started scully outside of a scully project-folder,
-or didn't install packages in this folder.
-We can't find your local copy to start.
-This can also happen on windows with PowerShell and mixed case path-names
---------------------------------------------------------------------------`);
-  }
-  process.exit(0);
-}
-
 // tslint:disable-next-line:radix
 if (parseInt(process.version.match(/^v(\d+\.\d+)/)[1]) < NODE_VERSION) {
   logError(`


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Scully checks whether it's running from a Scully project folder by comparing `__dirname` with `process.cwd()`. This breaks when the @scullyio/scully package is symlinked into the project dependencies since `__dirname` is resolved to the package symlink target location while `process.cwd()` returns the directory from which Scully was launched and where the symlink itself resides. This symlinking happens when using a tool such as [pnpm](https://pnpm.js.org/) to manage multiple projects in a monorepo and also when using `npm link` to install a locally modified copy of Scully into a test project during development. 

Issue Number: N/A

## What is the new behavior?
Scully no longer performs this check. Aside from enabling symlinked installation, this change also enables running Scully from sub-directories or in projects with hoisted dependencies such as those created by tools such as [Lerna](https://lerna.js.org/). 

If it's still important for Scully to only run in the root of a Scully project then we should consider verifying this in a way that doesn't present the issues described above such as checking for the presence of a Scully config file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
