### PR TITLE
feat(scully): add --disableProjectFolderCheck CLI option

### DIFF
--- a/docs/Reference/command-line-options.md
+++ b/docs/Reference/command-line-options.md
@@ -228,3 +228,11 @@ npx scully --noPrompt
 ```
 
 Alias `--np` or `--no-prompt`. You can skip the future user input question with `--noPrompt` flag. This flag can be used for undetectable CI/CD.
+
+#### disableProjectFolderCheck
+
+```bash
+npx scully --disableProjectFolderCheck
+```
+
+Disables checking if Scully was launched from the project folder. This allows installing Scully as a symlinked dependency such as when using [pnpm](https://pnpm.js.org/) or `npm link`. Use with caution as this may cause errors in certain environments.

--- a/libs/scully/src/lib/startBackgroundServer.ts
+++ b/libs/scully/src/lib/startBackgroundServer.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import { existsSync } from 'fs-extra';
 import { join } from 'path';
 import { captureMessage } from './utils/captureMessage';
-import { configFileName, handle404, logSeverity, pjFirst, tds, port } from './utils/cli-options';
+import { configFileName, handle404, logSeverity, pjFirst, tds, port, disableProjectFolderCheck } from './utils/cli-options';
 import { ScullyConfig } from './utils/interfacesandenums';
 import { green, log, logError } from './utils/log';
 
@@ -46,6 +46,9 @@ export function startBackgroundServer(scullyConfig: ScullyConfig) {
   if (port) {
     options.push('--port');
     options.push(String(port));
+  }
+  if (disableProjectFolderCheck) {
+    options.push('--disableProjectFolderCheck');
   }
 
   log(`Starting background servers with: node ${options.join(' ')}`);

--- a/libs/scully/src/lib/utils/cli-options.ts
+++ b/libs/scully/src/lib/utils/cli-options.ts
@@ -32,6 +32,7 @@ export const {
   tds,
   watch,
   stats,
+  disableProjectFolderCheck,
 } =
   /** return the argv */
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -185,7 +186,11 @@ export const {
     .boolean('stats')
     .alias('stats', 'statistics')
     .default('stats', false)
-    .describe('stats', 'Output select statistics to sucllyStats.json').argv;
+    .describe('stats', 'Output select statistics to sucllyStats.json')
+    /** Don't check if Scully was launched from project folder */
+    .boolean('disableProjectFolderCheck')
+    .default('disableProjectFolderCheck', false)
+    .describe('disableProjectFolderCheck', "Don't check if Scully was launched from project folder").argv;
 
 yargs.help();
 

--- a/libs/scully/src/scully.ts
+++ b/libs/scully/src/scully.ts
@@ -11,7 +11,7 @@ import './lib/pluginManagement/systemPlugins';
 import { startBackgroundServer } from './lib/startBackgroundServer';
 import { ScullyConfig, waitForServerToBeAvailable } from './lib/utils';
 import { captureException } from './lib/utils/captureMessage';
-import { hostName, openNavigator, removeStaticDist, ssl, watch } from './lib/utils/cli-options';
+import { hostName, openNavigator, removeStaticDist, ssl, watch, disableProjectFolderCheck } from './lib/utils/cli-options';
 import { loadConfig, scullyDefaults } from './lib/utils/config';
 import './lib/utils/exitHandler';
 import { installExitHandler } from './lib/utils/exitHandler';
@@ -32,7 +32,7 @@ if (process.argv.includes('version')) {
   process.exit(0);
 }
 
-if (!__dirname.includes(process.cwd())) {
+if (!disableProjectFolderCheck && !__dirname.includes(process.cwd())) {
   /** started from outside project folder, _or_ powershell with uppercase pathname */
   if (existsSync('./node_modules/@scullyio/scully/scully.js')) {
     execSync('node ./node_modules/@scullyio/scully/scully.js', {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Scully checks whether it's running from a Scully project folder and doesn't run if it can't find an installed copy of itself in `node_modules`. However this check fails when Scully is installed via symlinking such as when using a tool such as [pnpm](https://pnpm.js.org/) to manage multiple projects in a monorepo or when using `npm link` to install a locally modified copy of Scully into a test project during development. 

## What is the new behavior?
Scully supports a new CLI option `--disableProjectFolderCheck` which disables the project folder check. Aside from enabling symlinked installation, this change also enables running Scully from sub-directories or in projects with hoisted dependencies such as those created by tools such as [Lerna](https://lerna.js.org/). I've added this to a project of my own without issue so for projects that know what they're doing I think this is a good escape hatch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
See related:
https://github.com/scullyio/scully/issues/1177
https://github.com/scullyio/scully/pull/1217