### PR TITLE
docs(ng-lib): add useScullyTransferState description

### DIFF
--- a/docs/Reference/ngLib/transfer-state-service.md
+++ b/docs/Reference/ngLib/transfer-state-service.md
@@ -51,33 +51,3 @@ This method sets values to the property key.
 ```typescript
 setState<T>(name: string, val: T): void;
 ```
-
-## Caveats
-
-### Usage in Resolvers
-
-You can use the TransferState inside [`Resolvers`](https://angular.io/api/router/Resolve) to load
-the required data for a route before initializing the corresponding component. The router requires
-the observable to complete in order to continue with the navigation. This means that you might need
-to manually complete the observable, for example:
-
-```typescript
-@Injectable({ providedIn: 'root' })
-export class ScullyResolver implements Resolve<any> {
-  
-  constructor(
-    private service: DataService,
-    private transferState: TransferStateService
-  ) {}
-
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot ) {
-    const key = 'unique-data-key'
-    return this.transferState.useScullyTransferState(
-      key,
-      this.service.getData(key)
-    ).pipe(
-      take(1) // this will complete the observable
-    );
-  }
-}
-```

--- a/docs/Reference/ngLib/transfer-state-service.md
+++ b/docs/Reference/ngLib/transfer-state-service.md
@@ -15,13 +15,26 @@ position: 100
 
 The [`TransferStateService`](https://github.com/scullyio/scully/blob/main/libs/ng-lib/src/lib/transfer-state/transfer-state.service.ts) allows the transfer of an Angular application's state into the static site rendered by Scully.
 
+This allows Scully to use cached data instead of using the original data source (which is most likely
+an external API).
+
 More over, it allows you to load the state on subsequent route changes after the initial page has been loaded.
 
 A route change fetches the next route's state from the page on the serve, and it is returned to the client. Hence, having a state consumed as part of the build despite any CMS content in production
 
 ## Usage
 
-To get or set the application's state, use `getState` and `setState` below:
+#### `useScullyTransferState()`
+
+Use this method to have your existing observable data sources automatically
+included in Scully's TransferState. During development, your observables will behave as usual.
+
+When the static site is served, Scully will use the cached state instead of accessing the original
+observable data source.
+
+```typescript
+useScullyTransferState<T>(name: string, originalState: Observable<T>): Observable<T>
+```
 
 #### `getState()`
 
@@ -37,4 +50,34 @@ This method sets values to the property key.
 
 ```typescript
 setState<T>(name: string, val: T): void;
+```
+
+## Caveats
+
+### Usage in Resolvers
+
+You can use the TransferState inside [`Resolvers`](https://angular.io/api/router/Resolve) to load
+the required data for a route before initializing the corresponding component. The router requires
+the observable to complete in order to continue with the navigation. This means that you might need
+to manually complete the observable, for example:
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class ScullyResolver implements Resolve<any> {
+  
+  constructor(
+    private service: DataService,
+    private transferState: TransferStateService
+  ) {}
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot ) {
+    const key = 'unique-data-key'
+    return this.transferState.useScullyTransferState(
+      key,
+      this.service.getData(key)
+    ).pipe(
+      take(1) // this will complete the observable
+    );
+  }
+}
 ```


### PR DESCRIPTION
Added description for `useScullyTransferState`. Additionally provided some information regarding the usage of TransferState with Angular Route Resolvers.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Docs

## What is the current behavior?

n/a

## What is the new behavior?

New docs as described.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
