### PR TITLE
feat(scully): rename renderer to postProcessByHtml and add postProcessByDom

### DIFF
--- a/demos/plugins/errorPlugin.js
+++ b/demos/plugins/errorPlugin.js
@@ -10,4 +10,4 @@ const errorPlugin = async (html, options) => {
 };
 
 const validator = async (config) => [];
-registerPlugin('rendererHtml', 'errorPlugin', errorPlugin, validator);
+registerPlugin('postProcessByHtml', 'errorPlugin', errorPlugin, validator);

--- a/demos/plugins/tocPlugin.js
+++ b/demos/plugins/tocPlugin.js
@@ -25,4 +25,4 @@ const tocPlugin = async (html, options) => {
 };
 
 const validator = async (config) => [];
-registerPlugin('rendererHtml', 'toc', tocPlugin, validator);
+registerPlugin('postProcessByHtml', 'toc', tocPlugin, validator);

--- a/docs/Reference/plugins/overview.md
+++ b/docs/Reference/plugins/overview.md
@@ -22,15 +22,15 @@ When you want to [build your own plugin](/docs/Reference/plugins/custom-plugins/
 
 `router` plugins teach Scully how to get the required data to be pre-render pages from the route-params.
 
-#### [rendererHtml](/docs/Reference/plugins/types/render)
+#### [postProcessByHtml](/docs/Reference/plugins/types/render)
 
-`rendererHtml` plugins are used to transform the rendered HTML.
-After the Angular application renders, the HTML content is passed to a `rendererHtml` plugin where it can be further modified.
+`postProcessByHtml` plugins are used to transform the rendered HTML.
+After the Angular application renders, the HTML content is passed to a `postProcessByHtml` plugin where it can be further modified.
 
-#### [rendererDom](/docs/Reference/plugins/types/render)
+#### [postProcessByDom](/docs/Reference/plugins/types/render)
 
-`rendererDom` plugins are used to transform the rendered HTML.
-After the Angular application renders, the HTML content is passed to a `rendererDom` plugin where it can be further modified.
+`postProcessByDom` plugins are used to transform the rendered HTML.
+After the Angular application renders, the HTML content is passed to a `postProcessByDom` plugin where it can be further modified.
 
 ### [Route process](/docs/Reference/plugins/types/route-process)
 

--- a/docs/Reference/plugins/types/render.md
+++ b/docs/Reference/plugins/types/render.md
@@ -1,11 +1,11 @@
 ---
-title: rendererHtml Plugin Type
+title: postProcessByHtml Plugin Type
 published: true
 lang: en
 position: 100
 ---
 
-# `rendererHtml` Plugin Type
+# `postProcessByHtml` Plugin Type
 
 ## Overview
 
@@ -16,7 +16,7 @@ A **render plugin** could be used to transform a page containing markdown into a
 
 ## Interface
 
-A **`rendererHtml` plugin** is a function that returns a `Promise<String>`. The string in the promise must be the transformed
+A **`postProcessByHtml` plugin** is a function that returns a `Promise<String>`. The string in the promise must be the transformed
 HTML. The interface looks like this:
 
 ```typescript
@@ -28,9 +28,9 @@ function exampleContentPlugin(
 }
 ```
 
-## Making A `rendererHtml` Plugin
+## Making A `postProcessByHtml` Plugin
 
-The following **`rendererHtml` plugin** example adds a title to the header to a page if it does not find one.
+The following **`postProcessByHtml` plugin** example adds a title to the header to a page if it does not find one.
 
 ```typescript
 const { registerPlugin } = require('@scullyio/scully');
@@ -48,7 +48,12 @@ function defaultTitlePlugin(html, route) {
 
 // DON NOT FORGET REGISTER THE PLUGIN
 const validator = async (conf) => [];
-registerPlugin('rendererHtml', 'defaultTitle', defaultTitlePlugin, validator);
+registerPlugin(
+  'postProcessByHtml',
+  'defaultTitle',
+  defaultTitlePlugin,
+  validator
+);
 
 module.exports.defaultTitlePlugin = defaultTitlePlugin;
 ```
@@ -65,7 +70,7 @@ function smileEmojiPlugin(html, route) {
 }
 // DON NOT FORGET REGISTER THE PLUGIN
 const validator = async (conf) => [];
-registerPlugin('rendererHtml', 'smiles', smileEmojiPlugin, validator);
+registerPlugin('postProcessByHtml', 'smiles', smileEmojiPlugin, validator);
 
 module.exports.smileEmojiPlugin = smileEmojiPlugin;
 ```

--- a/docs/Reference/plugins/types/render_es.md
+++ b/docs/Reference/plugins/types/render_es.md
@@ -48,7 +48,12 @@ function defaultTitlePlugin(html, route) {
 
 // DON NOT FORGET REGISTER THE PLUGIN
 const validator = async (conf) => [];
-registerPlugin('rendererHtml', 'defaultTitle', defaultTitlePlugin, validator);
+registerPlugin(
+  'postProcessByHtml',
+  'defaultTitle',
+  defaultTitlePlugin,
+  validator
+);
 
 module.exports.defaultTitlePlugin = defaultTitlePlugin;
 ```
@@ -65,7 +70,7 @@ function smileEmojiPlugin(html, route) {
 }
 // DON NOT FORGET REGISTER THE PLUGIN
 const validator = async (conf) => [];
-registerPlugin('rendererHtml', 'smiles', smileEmojiPlugin, validator);
+registerPlugin('postProcessByHtml', 'smiles', smileEmojiPlugin, validator);
 
 module.exports.smileEmojiPlugin = smileEmojiPlugin;
 ```

--- a/docs/Reference/plugins/types/rendererDom.md
+++ b/docs/Reference/plugins/types/rendererDom.md
@@ -1,11 +1,11 @@
 ---
-title: rendererDom Plugin Type
+title: postProcessByDom Plugin Type
 published: true
 lang: en
 position: 100
 ---
 
-# `rendererDom` Plugin Type
+# `postProcessByDom` Plugin Type
 
 ## Overview
 
@@ -16,7 +16,7 @@ A **render plugin** could be used to transform a page containing markdown into a
 
 ## Interface
 
-A **`rendererDom` plugin** is a function that returns a `Promise<JSDOM>`. The string in the promise must be the transformed
+A **`postProcessByDom` plugin** is a function that returns a `Promise<JSDOM>`. The string in the promise must be the transformed
 HTML. The interface looks like this:
 
 ```typescript
@@ -28,8 +28,8 @@ function exampleContentPlugin(
 }
 ```
 
-## Difference with `rendererHtml` plugins
+## Difference with `postProcessByHtml` plugins
 
-While having exactly the same function as the `rendererHtml` the `rendererDom` plugins get, and shoudl return a JSDOM object. Those will be run before the `rendererHtml` are executed.
+While having exactly the same function as the `postProcessByHtml` the `postProcessByDom` plugins get, and shoudl return a JSDOM object. Those will be run before the `postProcessByHtml` are executed.
 
-## Sample of `rendererDom`
+## Sample of `postProcessByDom`

--- a/libs/plugins/base-href-rewrite/src/lib/plugins-base-href-rewrite.ts
+++ b/libs/plugins/base-href-rewrite/src/lib/plugins-base-href-rewrite.ts
@@ -24,4 +24,4 @@ setMyConfig(baseHrefRewritePlugin, {
   href: '/',
 });
 
-registerPlugin('rendererHtml', baseHrefRewrite, baseHrefRewritePlugin);
+registerPlugin('postProcessByHtml', baseHrefRewrite, baseHrefRewritePlugin);

--- a/libs/plugins/docs-link-update/src/lib/plugins-docs-link-update.ts
+++ b/libs/plugins/docs-link-update/src/lib/plugins-docs-link-update.ts
@@ -34,7 +34,7 @@ const docsLinkPlugin = async (dom: JSDOM, options: HandledRoute): Promise<JSDOM>
 };
 
 const validator = async (config) => [];
-registerPlugin('rendererDom', docLink, docsLinkPlugin, validator);
+registerPlugin('postProcessByDom', docLink, docsLinkPlugin, validator);
 
 function dropEndingSlash(str: string) {
   return str.endsWith('/') ? str.slice(0, -1) : str;

--- a/libs/plugins/google-analytics/src/lib/plugins-google-analytics.ts
+++ b/libs/plugins/google-analytics/src/lib/plugins-google-analytics.ts
@@ -26,4 +26,4 @@ export const googleAnalyticsPlugin = async (html: string): Promise<string> => {
 
 const validator = async () => [];
 
-registerPlugin('rendererHtml', GoogleAnalytics, googleAnalyticsPlugin, validator);
+registerPlugin('postProcessByHtml', GoogleAnalytics, googleAnalyticsPlugin, validator);

--- a/libs/plugins/logrocket/src/lib/plugins-logrocket.ts
+++ b/libs/plugins/logrocket/src/lib/plugins-logrocket.ts
@@ -18,4 +18,4 @@ export const logrocketPlugin = async (html: string): Promise<string> => {
 
 const validator = async () => [];
 
-registerPlugin('rendererHtml', LogRocket, logrocketPlugin, validator);
+registerPlugin('postProcessByHtml', LogRocket, logrocketPlugin, validator);

--- a/libs/plugins/scully-plugin-copy-to-clipboard/src/lib/plugins-scully-plugin-copy-to-clipboard.ts
+++ b/libs/plugins/scully-plugin-copy-to-clipboard/src/lib/plugins-scully-plugin-copy-to-clipboard.ts
@@ -117,4 +117,4 @@ const copyToClipboardPlugin = async (dom: JSDOM, options: HandledRoute): Promise
 
 const validator = async () => [];
 
-registerPlugin('rendererDom', copyToClipboard, copyToClipboardPlugin, validator);
+registerPlugin('postProcessByDom', copyToClipboard, copyToClipboardPlugin, validator);

--- a/libs/plugins/scully-plugin-critical-css/src/lib/plugins-scully-plugin-critical-css.ts
+++ b/libs/plugins/scully-plugin-critical-css/src/lib/plugins-scully-plugin-critical-css.ts
@@ -75,7 +75,7 @@ const criticalCssPlugin = async (incomingHtml: string, route: HandledRoute) => {
   }
   return incomingHtml;
 };
-registerPlugin('rendererHtml', criticalCSS, criticalCssPlugin);
+registerPlugin('postProcessByHtml', criticalCSS, criticalCssPlugin);
 
 function getStyleFiles(path) {
   const entries = readdirSync(path, { withFileTypes: true });

--- a/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
+++ b/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
@@ -9,7 +9,7 @@ const FlashPrevention = 'ScullyPluginFlashPrevention';
 const AppRootAttrsBlacklist = ['_nghost', 'ng-version'];
 const MockRootAttrsBlacklist = [];
 
-registerPlugin('rendererHtml', FlashPrevention, flashPreventionPlugin);
+registerPlugin('postProcessByHtml', FlashPrevention, flashPreventionPlugin);
 registerPlugin('router', FlashPrevention, async (ur) => [{ route: ur }]);
 
 interface FlashPreventionPluginOptions {

--- a/libs/plugins/scully-plugin-remove-scripts/src/lib/plugins-scully-plugin-remove-scripts.ts
+++ b/libs/plugins/scully-plugin-remove-scripts/src/lib/plugins-scully-plugin-remove-scripts.ts
@@ -48,4 +48,4 @@ const plugin = async (dom: JSDOM, route: HandledRoute) => {
   return dom;
 };
 
-registerPlugin('rendererDom', removeScripts, plugin);
+registerPlugin('postProcessByDom', removeScripts, plugin);

--- a/libs/plugins/sentry/src/lib/plugins-sentry.ts
+++ b/libs/plugins/sentry/src/lib/plugins-sentry.ts
@@ -45,4 +45,4 @@ export const sentryPlugin = async (html: string): Promise<string> => {
 
 const validator = async () => [];
 
-registerPlugin('rendererHtml', Sentry, sentryPlugin, validator);
+registerPlugin('postProcessByHtml', Sentry, sentryPlugin, validator);

--- a/libs/scully-schematics/src/add-plugin/schema.ts
+++ b/libs/scully-schematics/src/add-plugin/schema.ts
@@ -7,5 +7,5 @@ export interface Schema {
   /**
    * The type of plugin
    */
-  pluginType: 'router' | 'rendererHtml';
+  pluginType: 'router' | 'postProcessByHtml';
 }

--- a/libs/scully-schematics/src/files/plugin/render/__name@dasherize__.plugin.js.template
+++ b/libs/scully-schematics/src/files/plugin/render/__name@dasherize__.plugin.js.template
@@ -19,4 +19,4 @@ const validator = async conf => [];
 /**
   registerPlugin(TypeOfPlugin, name of the plugin, plugin function, validator)
 */
-registerPlugin('rendererHtml', '<%= camelize(name) %>', <%= camelize(name) %>, validator);
+registerPlugin('postProcessByHtml', '<%= camelize(name) %>', <%= camelize(name) %>, validator);

--- a/libs/scully-schematics/src/plugin-ts/index.ts
+++ b/libs/scully-schematics/src/plugin-ts/index.ts
@@ -46,7 +46,7 @@ const myFunctionPlugin = async (html: string): Promise<string> => {
 
 const validator = async () => [];
 
-registerPlugin('rendererHtml', myPlugin, myFunctionPlugin, validator);
+registerPlugin('postProcessByHtml', myPlugin, myFunctionPlugin, validator);
 `
   );
 };

--- a/libs/scully/src/lib/pluginManagement/Plugin.interfaces.ts
+++ b/libs/scully/src/lib/pluginManagement/Plugin.interfaces.ts
@@ -10,7 +10,7 @@ export type RoutePlugin = {
   (route?: string, config?: any): Promise<HandledRoute[]>;
   [configValidator]?: ConfigValidator | undefined;
 };
-export type rendererDomPlugin = (dom?: JSDOM, route?: HandledRoute) => Promise<JSDOM>;
+export type postProcessByDomPlugin = (dom?: JSDOM, route?: HandledRoute) => Promise<JSDOM>;
 export type RenderPlugin = (html?: string, route?: HandledRoute) => Promise<string>;
 export type RouteProcess = { (routes?: HandledRoute[]): Promise<HandledRoute[]>; [routeProcessPriority]?: number };
 export type RouteDiscoveryPlugin = (routes?: HandledRoute[]) => Promise<void>;
@@ -20,28 +20,28 @@ export type ScullySystemPlugin = (...args: unknown[]) => Promise<unknown>;
 export type EnterprisePlugin = (...args: unknown[]) => Promise<unknown>;
 
 export interface Plugins {
-  render: { [name: string]: RenderPlugin };
-  rendererHtml: { [name: string]: RenderPlugin };
-  rendererDom: { [name: string]: rendererDomPlugin };
-  router: { [name: string]: RoutePlugin };
-  routeProcess: { [name: string]: RouteProcess };
-  routeDiscoveryDone: { [name: string]: RouteDiscoveryPlugin };
   allDone: { [name: string]: AllDonePlugin };
-  fileHandler: { [fileExtension: string]: FilePlugin };
-  scullySystem: { [pluginSymbol: string]: (...args: unknown[]) => unknown };
   enterprise: { [pluginSymbol: string]: (...args: unknown[]) => unknown };
+  fileHandler: { [fileExtension: string]: FilePlugin };
+  postProcessByDom: { [name: string]: postProcessByDomPlugin };
+  postProcessByHtml: { [name: string]: RenderPlugin };
+  render: { [name: string]: RenderPlugin };
+  routeDiscoveryDone: { [name: string]: RouteDiscoveryPlugin };
+  routeProcess: { [name: string]: RouteProcess };
+  router: { [name: string]: RoutePlugin };
+  scullySystem: { [pluginSymbol: string]: (...args: unknown[]) => unknown };
 }
 export interface PluginFuncs {
-  rendererDom: rendererDomPlugin;
-  rendererHtml: RenderPlugin;
-  render: RenderPlugin;
-  router: RoutePlugin;
-  routeProcess: RouteProcess;
-  routeDiscoveryDone: RouteDiscoveryPlugin;
   allDone: AllDonePlugin;
-  fileHandler: FilePlugin;
-  scullySystem: (...args: unknown[]) => unknown;
   enterprise: (...args: unknown[]) => unknown;
+  fileHandler: FilePlugin;
+  postProcessByDom: postProcessByDomPlugin;
+  postProcessByHtml: RenderPlugin;
+  render: RenderPlugin;
+  routeDiscoveryDone: RouteDiscoveryPlugin;
+  routeProcess: RouteProcess;
+  router: RoutePlugin;
+  scullySystem: (...args: unknown[]) => unknown;
 }
 export type PluginTypes = keyof Plugins;
 

--- a/libs/scully/src/lib/pluginManagement/Plugin.interfaces.ts
+++ b/libs/scully/src/lib/pluginManagement/Plugin.interfaces.ts
@@ -11,7 +11,7 @@ export type RoutePlugin = {
   [configValidator]?: ConfigValidator | undefined;
 };
 export type postProcessByDomPlugin = (dom?: JSDOM, route?: HandledRoute) => Promise<JSDOM>;
-export type RenderPlugin = (html?: string, route?: HandledRoute) => Promise<string>;
+export type postProcessByHtmlPlugin = (html?: string, route?: HandledRoute) => Promise<string>;
 export type RouteProcess = { (routes?: HandledRoute[]): Promise<HandledRoute[]>; [routeProcessPriority]?: number };
 export type RouteDiscoveryPlugin = (routes?: HandledRoute[]) => Promise<void>;
 export type AllDonePlugin = (routes?: HandledRoute[]) => Promise<void>;
@@ -24,8 +24,8 @@ export interface Plugins {
   enterprise: { [pluginSymbol: string]: (...args: unknown[]) => unknown };
   fileHandler: { [fileExtension: string]: FilePlugin };
   postProcessByDom: { [name: string]: postProcessByDomPlugin };
-  postProcessByHtml: { [name: string]: RenderPlugin };
-  render: { [name: string]: RenderPlugin };
+  postProcessByHtml: { [name: string]: postProcessByHtmlPlugin };
+  render: { [name: string]: postProcessByHtmlPlugin };
   routeDiscoveryDone: { [name: string]: RouteDiscoveryPlugin };
   routeProcess: { [name: string]: RouteProcess };
   router: { [name: string]: RoutePlugin };
@@ -36,8 +36,8 @@ export interface PluginFuncs {
   enterprise: (...args: unknown[]) => unknown;
   fileHandler: FilePlugin;
   postProcessByDom: postProcessByDomPlugin;
-  postProcessByHtml: RenderPlugin;
-  render: RenderPlugin;
+  postProcessByHtml: postProcessByHtmlPlugin;
+  render: postProcessByHtmlPlugin;
   routeDiscoveryDone: RouteDiscoveryPlugin;
   routeProcess: RouteProcess;
   router: RoutePlugin;

--- a/libs/scully/src/lib/pluginManagement/pluginRepository.ts
+++ b/libs/scully/src/lib/pluginManagement/pluginRepository.ts
@@ -10,30 +10,31 @@ export const accessPluginDirectly = Symbol('accessPluginDirectly');
 export const routeProcessPriority = Symbol('routeProcessPriority');
 export const scullySystem = `scullySystem`;
 
-const rendererHtml = {};
+const postProcessByHtml = {};
 
 export const plugins: Plugins = {
-  render: rendererHtml,
-  rendererHtml,
-  rendererDom: {},
-  router: {},
-  fileHandler: {},
-  routeProcess: {},
-  routeDiscoveryDone: {},
   allDone: {},
   enterprise: {},
+  fileHandler: {},
+  postProcessByDom: {},
+  postProcessByHtml: postProcessByHtml,
+  render: postProcessByHtml,
+  routeDiscoveryDone: {},
+  routeProcess: {},
+  router: {},
   scullySystem: {},
 };
 
 export const pluginTypes = [
-  'router',
-  'render',
-  'rendererDom',
-  'routeProcess',
-  'fileHandler',
   'allDone',
-  'routeDiscoveryDone',
   'enterprise',
+  'fileHandler',
+  'postProcessByDom',
+  'postProcessByHtml',
+  'render',
+  'routeDiscoveryDone',
+  'routeProcess',
+  'router',
   'scullySystem',
 ] as const;
 
@@ -58,12 +59,12 @@ export const registerPlugin = <T extends keyof PluginFuncs>(
       plugin[routeProcessPriority] = typeof pluginOptions === 'number' ? pluginOptions : 100;
       break;
     case 'render':
-      logWarn(`Using deprecated plugin type:"${yellow('render')}"  use "${yellow('rendererHtml')}" instead`);
+      logWarn(`Using deprecated plugin type:"${yellow('render')}"  use "${yellow('postProcessByHtml')}" instead`);
       break;
     case 'allDone':
     case 'enterprise':
-    case 'rendererHtml':
-    case 'rendererDom':
+    case 'postProcessByHtml':
+    case 'postProcessByDom':
     case 'routeDiscoveryDone':
     case 'scullySystem':
       break;
@@ -88,7 +89,7 @@ function assertNeverForPluginType(type: never | string, name: string): never {
   ----------------------------------------------------------------------------------------------
     Type "${yellow(type)}" is not a known plugin type for registering plugin "${yellow(name)}".
     The first parameter of registerPlugin needs to be one of:
-    'fileHandler', 'router', 'render', 'rendererDom', 'routeProcess', 'allDone', 'enterprise', or 'routeDiscoveryDone'
+    'fileHandler', 'router', 'render', 'postProcessByDom', 'routeProcess', 'allDone', 'enterprise', or 'routeDiscoveryDone'
   ----------------------------------------------------------------------------------------------
   `);
 }

--- a/libs/scully/src/lib/pluginManagement/pluginWrap.ts
+++ b/libs/scully/src/lib/pluginManagement/pluginWrap.ts
@@ -32,8 +32,8 @@ export async function wrap(type: string, name: string | symbol, plugin: (...args
       id += args[0];
       currentRoute = args[0];
     case 'render':
-    case 'rendererHtml':
-    case 'rendererDom':
+    case 'postProcessByHtml':
+    case 'postProcessByDom':
       id += args[1].route;
       currentRoute = args[1].route;
     case 'fileHandler':

--- a/libs/scully/src/lib/renderPlugins/contentRenderPlugin.ts
+++ b/libs/scully/src/lib/renderPlugins/contentRenderPlugin.ts
@@ -5,7 +5,7 @@ import { logWarn, yellow } from '../utils/log';
 import { convertAndInjectContent } from './content-render-utils/convertAndInjectContent';
 import { readFileAndCheckPrePublishSlug } from './content-render-utils/readFileAndCheckPrePublishSlug';
 
-registerPlugin('rendererDom', 'contentFolder', contentRenderPlugin);
+registerPlugin('postProcessByDom', 'contentFolder', contentRenderPlugin);
 
 export async function contentRenderPlugin(dom: JSDOM, route: HandledRoute): Promise<JSDOM> {
   const file = route.templateFile;

--- a/libs/scully/src/lib/renderPlugins/contentTextRenderPlugin.ts
+++ b/libs/scully/src/lib/renderPlugins/contentTextRenderPlugin.ts
@@ -3,7 +3,7 @@ import { registerPlugin } from '../pluginManagement/pluginRepository';
 import { ContentTextRoute } from '../routerPlugins/handledRoute.interface';
 import { logError, yellow } from '../utils/log';
 import { convertAndInjectContent } from './content-render-utils/convertAndInjectContent';
-registerPlugin('rendererDom', 'contentText', contentTextRenderPlugin);
+registerPlugin('postProcessByDom', 'contentText', contentTextRenderPlugin);
 
 export async function contentTextRenderPlugin(dom: JSDOM, route: ContentTextRoute): Promise<JSDOM> {
   const contentType = route.contentType || route.config.contentType;

--- a/libs/scully/src/lib/renderPlugins/executePlugins.ts
+++ b/libs/scully/src/lib/renderPlugins/executePlugins.ts
@@ -7,7 +7,7 @@ import { captureException } from '../utils/captureMessage';
 import { puppeteerRender } from './puppeteerRenderPlugin';
 import { toJSDOM, fromJSDOM } from './jsdomPlugins';
 import { JSDOM } from 'jsdom';
-import { rendererDomPlugin, RenderPlugin } from '../pluginManagement';
+import { postProcessByDomPlugin, RenderPlugin } from '../pluginManagement';
 
 export const renderRoute = Symbol('renderRoute');
 
@@ -35,18 +35,18 @@ const executePluginsForRoute = async (route: HandledRoute) => {
   // split out jsDom vs string renderers.
   const { jsDomRenders, renders: stringRenders } = handlers.reduce(
     (result, plugin) => {
-      const textHandler = findPlugin(plugin, 'rendererHtml', false) as RenderPlugin;
+      const textHandler = findPlugin(plugin, 'postProcessByHtml', false) as RenderPlugin;
       if (textHandler !== undefined) {
         result.renders.push({ plugin, handler: textHandler });
       }
-      const jsDomHandler = findPlugin(plugin, 'rendererDom', false) as rendererDomPlugin;
+      const jsDomHandler = findPlugin(plugin, 'postProcessByDom', false) as postProcessByDomPlugin;
       if (jsDomHandler !== undefined) {
         result.jsDomRenders.push({ plugin, handler: jsDomHandler });
       }
       return result;
     },
     { jsDomRenders: [], renders: [] } as {
-      jsDomRenders: { plugin: string | symbol; handler: rendererDomPlugin }[];
+      jsDomRenders: { plugin: string | symbol; handler: postProcessByDomPlugin }[];
       renders: { plugin: string | symbol; handler: RenderPlugin }[];
     }
   );

--- a/libs/scully/src/lib/renderPlugins/executePlugins.ts
+++ b/libs/scully/src/lib/renderPlugins/executePlugins.ts
@@ -7,7 +7,7 @@ import { captureException } from '../utils/captureMessage';
 import { puppeteerRender } from './puppeteerRenderPlugin';
 import { toJSDOM, fromJSDOM } from './jsdomPlugins';
 import { JSDOM } from 'jsdom';
-import { postProcessByDomPlugin, RenderPlugin } from '../pluginManagement';
+import { postProcessByDomPlugin, postProcessByHtmlPlugin } from '../pluginManagement';
 
 export const renderRoute = Symbol('renderRoute');
 
@@ -35,7 +35,7 @@ const executePluginsForRoute = async (route: HandledRoute) => {
   // split out jsDom vs string renderers.
   const { jsDomRenders, renders: stringRenders } = handlers.reduce(
     (result, plugin) => {
-      const textHandler = findPlugin(plugin, 'postProcessByHtml', false) as RenderPlugin;
+      const textHandler = findPlugin(plugin, 'postProcessByHtml', false) as postProcessByHtmlPlugin;
       if (textHandler !== undefined) {
         result.renders.push({ plugin, handler: textHandler });
       }
@@ -47,7 +47,7 @@ const executePluginsForRoute = async (route: HandledRoute) => {
     },
     { jsDomRenders: [], renders: [] } as {
       jsDomRenders: { plugin: string | symbol; handler: postProcessByDomPlugin }[];
-      renders: { plugin: string | symbol; handler: RenderPlugin }[];
+      renders: { plugin: string | symbol; handler: postProcessByHtmlPlugin }[];
     }
   );
 

--- a/libs/scully/src/lib/renderPlugins/seoHrefCompletionPlugin.ts
+++ b/libs/scully/src/lib/renderPlugins/seoHrefCompletionPlugin.ts
@@ -38,7 +38,7 @@ const seoHrefPlugin = async (dom: JSDOM, route: HandledRoute): Promise<JSDOM> =>
   return dom;
 };
 
-registerPlugin('rendererDom', 'seoHrefOptimise', seoHrefPlugin);
+registerPlugin('postProcessByDom', 'seoHrefOptimise', seoHrefPlugin);
 
 /** copied from ng-lib  */
 function basePathOnly(str: string): string {

--- a/releaseChecksums.json
+++ b/releaseChecksums.json
@@ -5,7 +5,7 @@
     "dist": "dist/libs/scully",
     "pkg": "@scullyio/scully",
     "version": "1.0.11",
-    "hash": "d6a21c88f6124ef9503fa6a9bbbdde85"
+    "hash": "5cbe6ee4da43afc4ae3fbf973ff2892f"
   },
   {
     "name": "ng-lib",

--- a/scully.scully-docs.config.ts
+++ b/scully.scully-docs.config.ts
@@ -80,7 +80,7 @@ async function createConfig(): Promise<ScullyConfig> {
     },
   };
 }
-registerPlugin('rendererDom', 'docs-toc', async (dom, route) => {
+registerPlugin('postProcessByDom', 'docs-toc', async (dom, route) => {
   const headingIds = getHeadings(readFileSync(route.templateFile, 'utf-8').toString());
   const toc = `<ul>${headingIds.map(createLi).join('')}</ul>`;
   const heads = headingIds.map((h) => h[1]);

--- a/scully/plugins/error.ts
+++ b/scully/plugins/error.ts
@@ -10,4 +10,4 @@ const errorPlugin = async (html, options) => {
 };
 
 const validator = async (config) => [];
-registerPlugin('rendererHtml', 'errorPlugin', errorPlugin, validator);
+registerPlugin('postProcessByHtml', 'errorPlugin', errorPlugin, validator);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Renderer plugins are now renamed to postProcessbyHtml and using the old name will display a deprecation warning.
## Other information
