### PR TITLE
fix(schematics): fix the scripts in package.json

### DIFF
--- a/libs/scully-schematics/src/scully/index.ts
+++ b/libs/scully-schematics/src/scully/index.ts
@@ -28,8 +28,8 @@ const modifyPackageJson = (options: Schema) => (tree: Tree, context: SchematicCo
 
   const params = projectName === defaultProjectName ? '' : ` --project ${projectName}`;
   const jsonContent = getPackageJson(tree);
-  jsonContent.scripts.scully = 'npm scully --' + params;
-  jsonContent.scripts['scully:serve'] = 'npx scully serve --' + params;
+  jsonContent.scripts.scully = 'scully' + params;
+  jsonContent.scripts['scully:serve'] = 'scully serve' + params;
   overwritePackageJson(tree, jsonContent);
   context.logger.info('✅️ Update package.json');
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

After we run the build/serve script, it will get an error like the following:

```
$ npm run scully

> scully@0.0.0 scully /Users/leo/Documents/Angular小聚/2021/scully
> npm scully --


Usage: npm <command>

where <command> is one of:
    access, adduser, audit, bin, bugs, c, cache, ci, cit,
    clean-install, clean-install-test, completion, config,
    create, ddp, dedupe, deprecate, dist-tag, docs, doctor,
    edit, explore, fund, get, help, help-search, hook, i, init,
    install, install-ci-test, install-test, it, link, list, ln,
    login, logout, ls, org, outdated, owner, pack, ping, prefix,
    profile, prune, publish, rb, rebuild, repo, restart, root,
    run, run-script, s, se, search, set, shrinkwrap, star,
    stars, start, stop, t, team, test, token, tst, un,
    uninstall, unpublish, unstar, up, update, v, version, view,
    whoami

npm <command> -h  quick help on <command>
npm -l            display full usage info
npm help <term>   search for help on <term>
npm help npm      involved overview

Specify configs in the ini-formatted file:
    /Users/leo/.npmrc
or on the command line via: npm <command> --key value
Config info can be viewed via: npm help config

npm@6.14.5 /Users/leo/.nvm/versions/node/v14.5.0/lib/node_modules/npm

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! scully@0.0.0 scully: `npm scully --`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the scully@0.0.0 scully script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/leo/.npm/_logs/2021-02-24T01_42_59_774Z-debug.log
```

## What is the new behavior?

It will build/serve correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
