### PR TITLE
fix: fix scripts.scully script to use npx instead of npm

### DIFF
--- a/libs/scully-schematics/src/scully/index.ts
+++ b/libs/scully-schematics/src/scully/index.ts
@@ -28,7 +28,7 @@ const modifyPackageJson = (options: Schema) => (tree: Tree, context: SchematicCo
 
   const params = projectName === defaultProjectName ? '' : ` --project ${projectName}`;
   const jsonContent = getPackageJson(tree);
-  jsonContent.scripts.scully = 'npm scully --' + params;
+  jsonContent.scripts.scully = 'npx scully --' + params;
   jsonContent.scripts['scully:serve'] = 'npx scully serve --' + params;
   overwritePackageJson(tree, jsonContent);
   context.logger.info('✅️ Update package.json');


### PR DESCRIPTION
Before:
` jsonContent.scripts.scully = 'npm scully --' + params;`
After:
` jsonContent.scripts.scully = 'npx scully --' + params;`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
