### PR TITLE
feat(ng-lib) Add property decorator to provide TransferStateService functionality

### DIFF
--- a/docs/Reference/ngLib/transfer-state-service.md
+++ b/docs/Reference/ngLib/transfer-state-service.md
@@ -24,6 +24,33 @@ A route change fetches the next route's state from the page on the serve, and it
 
 ## Usage
 
+#### `@ScullyTransferState()`
+
+Use this decorator to annotate which Observable-type properties should automatically be included
+in Scully's TransferState. During development, your observables will behave as usual.
+
+When the static site is served, Scully will use the cached state instead of accessing the original
+observable data source.
+
+This decorator is a convenience wrapper for `useScullyTransferState()`. An optional key for the
+state can be specified using the `name` argument. If you have multiple instances of the same
+component on the same page you must use `useScullyTransferState()` instead.
+
+```typescript
+ScullyTransferState(name?: string): PropertyDecorator
+```
+
+Example
+
+```typescript
+export class AppComponent {
+  @ScullyTransferState()
+  public myData$: Observable<MyData> = this.myDataService.getMyData();
+
+  constructor(private myDataService: MyDataService) {}
+}
+```
+
 #### `useScullyTransferState()`
 
 Use this method to have your existing observable data sources automatically

--- a/libs/ng-lib/src/lib/scully-lib.module.ts
+++ b/libs/ng-lib/src/lib/scully-lib.module.ts
@@ -2,6 +2,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { ScullyDefaultSettings, ScullyLibConfig, SCULLY_LIB_CONFIG } from './config/scully-config';
 import { IdleMonitorService } from './idleMonitor/idle-monitor.service';
 import { ScullyContentModule } from './scully-content/scully-content.module';
+import { setGlobalTransferStateService, TransferStateService } from './transfer-state/transfer-state.service';
 
 @NgModule({
   imports: [ScullyContentModule],
@@ -10,8 +11,8 @@ import { ScullyContentModule } from './scully-content/scully-content.module';
 export class ScullyLibModule {
   /**
    * We use a little trick to get a working idle-service.
-   * First, we separate out the component in a separate module to prevent a circulair injection
-   * second we create a constuctor that activates the IdleMonitorService. as that is provided for 'root'
+   * First, we separate out the component in a separate module to prevent a circular injection
+   * second we create a constructor that activates the IdleMonitorService. as that is provided for 'root'
    * there will be only 1 instance in our app.
    * We don't need forRoot, as we are not configuring anything in here.
    */
@@ -22,5 +23,7 @@ export class ScullyLibModule {
       providers: [{ provide: SCULLY_LIB_CONFIG, useValue: config }],
     };
   }
-  constructor(private idle: IdleMonitorService) {}
+  constructor(private idle: IdleMonitorService, transferStateService: TransferStateService) {
+    setGlobalTransferStateService(transferStateService);
+  }
 }

--- a/libs/ng-lib/src/lib/transfer-state/transfer-state-decorator.ts
+++ b/libs/ng-lib/src/lib/transfer-state/transfer-state-decorator.ts
@@ -1,0 +1,52 @@
+import { injectGlobalTransferStateService, TransferStateService } from './transfer-state.service';
+import { Observable } from 'rxjs';
+
+// tslint:disable:no-bitwise
+// From https://stackoverflow.com/a/52171480
+function cyrb53(str, seed = 0) {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}
+// tslint:enable:no-bitwise
+
+export function ScullyTransferState(name?: string) {
+  return <K extends string, T extends Record<K, Observable<any>>>(target: T, propertyKey: K) => {
+    const defaultAttributes = {
+      configurable: true,
+      enumerable: true,
+    };
+
+    Object.defineProperty(target, propertyKey, {
+      ...defaultAttributes,
+      set: (value) => {
+        if (!(value instanceof Observable)) {
+          throw new TypeError('TransferState decorator cannot decorate property that is not of type Observable');
+        }
+
+        const transferStateService: TransferStateService = injectGlobalTransferStateService();
+        const wrappedValue = transferStateService.useScullyTransferState(name ?? getStateKey(target, propertyKey), value);
+
+        Object.defineProperty(target, propertyKey, {
+          ...defaultAttributes,
+          writable: true,
+          value: wrappedValue,
+        });
+      },
+    });
+  };
+}
+
+function getStateKey(target: object, propertyKey: string): string {
+  return `${cyrb53(target.constructor.toString()).toString(36)}_${propertyKey}`;
+}

--- a/libs/ng-lib/src/lib/transfer-state/transfer-state.service.ts
+++ b/libs/ng-lib/src/lib/transfer-state/transfer-state.service.ts
@@ -25,6 +25,17 @@ declare global {
 interface State {
   [key: string]: any;
 }
+
+let globalTransferStateService: TransferStateService;
+
+export function injectGlobalTransferStateService(): TransferStateService {
+  return globalTransferStateService;
+}
+
+export function setGlobalTransferStateService(value: TransferStateService) {
+  globalTransferStateService = value;
+}
+
 // Adding this dynamic comment to suppress ngc error around Document as a DI token.
 // https://github.com/angular/angular/issues/20351#issuecomment-344009887
 /** @dynamic */

--- a/libs/ng-lib/src/public-api.ts
+++ b/libs/ng-lib/src/public-api.ts
@@ -2,16 +2,11 @@
  * Public API Surface of ng-lib
  */
 
-export {
-  IdleMonitorService,
-  dropEndingSlash,
-} from './lib/idleMonitor/idle-monitor.service';
-export {
-  ScullyRoutesService,
-  ScullyRoute,
-} from './lib/route-service/scully-routes.service';
+export { IdleMonitorService, dropEndingSlash } from './lib/idleMonitor/idle-monitor.service';
+export { ScullyRoutesService, ScullyRoute } from './lib/route-service/scully-routes.service';
 export { ScullyContentComponent } from './lib/scully-content/scully-content.component';
 export { ScullyContentModule } from './lib/scully-content/scully-content.module';
 export { ScullyLibModule } from './lib/scully-lib.module';
 export { TransferStateService } from './lib/transfer-state/transfer-state.service';
 export { isScullyGenerated, isScullyRunning } from './lib/utils/isScully';
+export { ScullyTransferState } from './lib/transfer-state/transfer-state-decorator';


### PR DESCRIPTION
ISSUES CLOSED: #1191

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Not seeing any existing tests for ng-lib functionality related to TransferStateService. Not sure what the recommended way is to test something like this for this project.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1191

## What is the new behavior?

Introduced `@ScullyTransferState()` property decorator for decorating Observable properties to be wrapped with `useScullyTransferState()`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
