### PR TITLE
fix(scully): Remove exit process before finishing execution

### DIFF
--- a/libs/scully/src/lib/utils/startup.ts
+++ b/libs/scully/src/lib/utils/startup.ts
@@ -99,9 +99,6 @@ ${yellow('------------------------------------------------------------')}`
       );
       writeFileSync(scullyStatsFilePath, JSON.stringify(scullyStats, undefined, 4));
     }
-    if (!watch) {
-      process.exit(0);
-    }
   });
 };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other... Please describe: Rollback this PR https://github.com/scullyio/scully/pull/1334 changes.

## What is the current behavior?

Currently, the `process.exit(0)` in the `startup.ts` is making these code https://github.com/scullyio/scully/blob/main/libs/scully/src/scully.ts#L164-L171 never be executed, leaving the `serve` process opened in the port `1864`

Issue Number: https://github.com/scullyio/scully/issues/1397

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

To Scully runs without any problems in the CI/CD environments, this issue should be resolved first: https://github.com/scullyio/scully/issues/1348