### PR TITLE
feat(scully): consider Content-Type passed in headers in httpGetJson

### DIFF
--- a/docs/Reference/plugins/built-in-plugins/json.md
+++ b/docs/Reference/plugins/built-in-plugins/json.md
@@ -102,6 +102,14 @@ export const config: ScullyConfig = {
          * header name is the key, and the header value is the value.
          */
         headers: {
+          /**
+           * expectedContentType: string
+           *
+           * By default plugin expects `application/json` Content-Type in response headers.
+           * If the API returns different type of content use the `expectedContentType` to specify
+           * different type. Error will be thrown if content types do not match.
+           */
+          expectedContentType: 'application/vnd.api+json',
           'API-KEY': '0123456789',
         },
         /**

--- a/libs/scully/src/lib/utils/httpGetJson.ts
+++ b/libs/scully/src/lib/utils/httpGetJson.ts
@@ -44,15 +44,23 @@ You can ignore the warning (TLS) or run scully with --no-warning
     };
     httpGet(opt, res => {
       const { statusCode } = res;
-      const contentType = res.headers['content-type'];
+      const responseContentType = res.headers['content-type'];
+      let contentType = 'application/json';
+      if (headers && headers['Content-Type']) {
+        contentType = headers['Content-Type'];
+      }
       let error: Error;
       if (statusCode !== 200) {
-        error = new Error(`Request Failed. Received status code: ${statusCode}
-on url: ${url}`);
-      } else if (!/^application\/json/.test(contentType)) {
-        error = new Error(`Invalid content-type.
-Expected application/json but received ${contentType}
-on url: ${url}`);
+        error = new Error(
+          `Request Failed. Received status code: ${statusCode} on url: ${url}`
+        );
+      }
+      else if (!responseContentType.startsWith(contentType)) {
+        error = new Error(
+          `Invalid content-type.
+          Expected ${contentType} but received ${responseContentType}
+          on url: ${url}`
+        );
       }
       if (error) {
         // console.error(error.message);

--- a/libs/scully/src/lib/utils/httpGetJson.ts
+++ b/libs/scully/src/lib/utils/httpGetJson.ts
@@ -46,8 +46,8 @@ You can ignore the warning (TLS) or run scully with --no-warning
       const { statusCode } = res;
       const responseContentType = res.headers['content-type'];
       let contentType = 'application/json';
-      if (headers && headers['Content-Type']) {
-        contentType = headers['Content-Type'];
+      if (headers && headers.expectedContentType) {
+        contentType = headers.expectedContentType;
       }
       let error: Error;
       if (statusCode !== 200) {

--- a/libs/scully/src/lib/utils/interfacesandenums.ts
+++ b/libs/scully/src/lib/utils/interfacesandenums.ts
@@ -88,6 +88,7 @@ export type RouteTypeJson = {
 };
 
 export interface HeadersObject {
+  expectedContentType?: string;
   [headerName: string]: string;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Passing `Content-Type` in route headers is not being considered in `httpGetJson` method. This restricts developers to stick to `application/json` type only.

## What is the new behavior?

httpGetJson method now checks whether `content-type` matches with specified `Content-Type` in headers passed in scully config file. If not specified, then it compares content types by default to `application/json`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Resubmitting https://github.com/scullyio/scully/pull/1405 since I had no proper email attached to branch commits required to sign CLA.
