### PR TITLE
docs(scully): fix documentation snippet on router plugin type page

### DIFF
--- a/docs/Reference/plugins/types/router.md
+++ b/docs/Reference/plugins/types/router.md
@@ -29,8 +29,8 @@ A **`router` plugin** is used to convert the raw route-config into a list of rou
 
 Lets implement a **`router` plugin** that turns the raw route into five distinct `HandledRoutes` from an application containing the following route: `/user/:userId`.
 
-```javascript
-const { registerPlugin } = require('@scullyio/scully');
+```typescript
+import { HandledRoute, registerPlugin } from "@scullyio/scully"
 
 function userIdPlugin(route: string, config = {}): Promise<HandledRoute[]> {
   return Promise.resolve([


### PR DESCRIPTION
The second code snippet on
https://scully.io/docs/Reference/plugins/types/router/ page is incorrect
for two reasons. Firstly, the snippet is marked as 'Javascript' but it's
strongly typed (uses Typescript) and secondly the 'HandledRoute' is
missing. Change the marked language and update the imports
accordingly.

BREAKING CHANGE:  None

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The second code snippet on
https://scully.io/docs/Reference/plugins/types/router/ page is incorrect
for two reasons. Firstly, the snippet is marked as 'Javascript' but it's
strongly typed (uses Typescript) and secondly the 'HandledRoute' is
missing.

Issue Number: N/A

The marked language is now set to 'Typescript and the import section has been updated accordingly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
None