### PR TITLE
fix(scully): markdown add support for SQL code blocks

### DIFF
--- a/libs/scully/src/lib/fileHanderPlugins/markdown.ts
+++ b/libs/scully/src/lib/fileHanderPlugins/markdown.ts
@@ -16,10 +16,11 @@ import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-tsx';
 import 'prismjs/components/prism-docker';
+import 'prismjs/components/prism-sql';
 
 const renderer = new marked.Renderer();
 // wrap code block the way Prism.js expects it
-renderer.code = function (this:any ,code, lang, escaped) {
+renderer.code = function (this: any, code, lang, escaped) {
   code = this.options.highlight(code, lang);
   if (!lang) {
     return '<pre><code>' + code + '</code></pre>';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Syntax highlighting does not work for SQL language markdown code blocks.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Syntax highlighting will work for SQL language codeblocks.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
