### PR TITLE
Fix Windows parent folder with space

### DIFF
--- a/libs/scully/src/lib/utils/compileConfig.ts
+++ b/libs/scully/src/lib/utils/compileConfig.ts
@@ -117,7 +117,7 @@ async function compileUserPluginsAndConfig() {
       process.exit(15);
     }
     return new Promise((resolve, reject) => {
-      exec(`npx tsc -p ${configPath}`, (err, res) => {
+      exec(`npx tsc -p "${configPath}"`, (err, res) => {
         // console.log(err, res);
         if (res) {
           logError('Typescript error while compiling plugins. the error is:');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
Current users who have a space in their path for example
`C:\Users\Evan Johnson\source\repos\samplerepo` are unable to run scully without manually editing the node package.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In order to fix this I have added "" around the path in the command.
Issue Number: 
fixes #1425 

## What is the new behavior?
Allow scully commands to work for windows users whose path contain spaces.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
