### PR TITLE
fix(scully): kill background server on exit

### DIFF
--- a/libs/scully/src/lib/utils/serverstuff/staticServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/staticServer.ts
@@ -21,11 +21,10 @@ const dotProps = readAllDotProps();
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function staticServer(port?: number) {
   try {
-    const {hostName, distFolder} = dotProps;
+    const { hostName, distFolder } = dotProps;
 
     port = port || dotProps.staticPort;
     const scullyServer = express();
-    // const distFolder = join(scullyConfig.homeFolder, scullyConfig.hostFolder || scullyConfig.distFolder);
 
     if (tds) {
       dataServerInstance = await startDataServer(ssl);
@@ -71,7 +70,7 @@ export async function staticServer(port?: number) {
     angularDistServer.get('/_pong', (req, res) => {
       res.json({
         res: true,
-        ...readAllDotProps()
+        ...readAllDotProps(),
       });
     });
     angularDistServer.get('/killMe', async (req, res) => {
@@ -89,13 +88,9 @@ export async function staticServer(port?: number) {
 
     angularDistServer.get('/*', handleUnknownRoute);
 
-    angularServerInstance = addSSL(angularDistServer, hostName, dotProps.appPort).listen(
-      dotProps.appPort,
-      hostName,
-      (x) => {
-        logOk(`Started Angular distribution server on "${yellow(`http${ssl ? 's' : ''}://${hostName}:${dotProps.appPort}/`)}" `);
-      }
-    );
+    angularServerInstance = addSSL(angularDistServer, hostName, dotProps.appPort).listen(dotProps.appPort, hostName, (x) => {
+      logOk(`Started Angular distribution server on "${yellow(`http${ssl ? 's' : ''}://${hostName}:${dotProps.appPort}/`)}" `);
+    });
     return {
       angularDistServer,
       scullyServer,


### PR DESCRIPTION
This will forcefully kill the background server when scully is done processing

ISSUES CLOSED: #1513

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
