### PR TITLE
fix(scully-plugin-puppeteer): rename `onRenderReady` event to prevent zone.js patching

### DIFF
--- a/libs/plugins/scully-plugin-playwright/src/lib/plugins-scully-plugin-playwright.ts
+++ b/libs/plugins/scully-plugin-playwright/src/lib/plugins-scully-plugin-playwright.ts
@@ -51,7 +51,7 @@ export const playwrightRenderer = async (route: HandledRoute): Promise<string> =
     }
 
     /** this will be called from the browser, but runs in node */
-    await page.exposeFunction('onRenderReady', () => {
+    await page.exposeFunction('pageRenderReady', () => {
       resolve();
     });
 
@@ -79,7 +79,7 @@ export const playwrightRenderer = async (route: HandledRoute): Promise<string> =
       /** set "running" mode */
       window['ScullyIO'] = 'running';
       window.addEventListener('AngularReady', () => {
-        window['onRenderReady']();
+        window['pageRenderReady']();
       });
     });
 

--- a/libs/plugins/scully-plugin-puppeteer/src/lib/plugins-scully-plugin-puppeteer.ts
+++ b/libs/plugins/scully-plugin-puppeteer/src/lib/plugins-scully-plugin-puppeteer.ts
@@ -96,7 +96,7 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
     }
 
     /** this will be called from the browser, but runs in node */
-    await page.exposeFunction('onRenderReady', () => {
+    await page.exposeFunction('pageRenderReady', () => {
       resolve();
     });
 
@@ -125,7 +125,7 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
       /** set "running" mode */
       window['ScullyIO'] = 'running';
       window.addEventListener('AngularReady', () => {
-        window['onRenderReady']();
+        window['pageRenderReady']();
       });
     });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Since version 0.11.5 Zone.Js [patches all window properties started from `on` prefix](https://github.com/angular/angular/blob/0f298a13dbd141e5440d1388b124d03384641efe/packages/zone.js/lib/browser/property-descriptor.ts#L51). Puppeteer plugin uses `onRenderReady` event to notify puppetteer.  So Zone patching makes impossible for puppeteer to receive such event, which causing to always wait for default 25sec timeout on Scully build for Angular projects.

Issue Number: N/A

## What is the new behavior?

Puppeteer doesn't always wait for timeout and processes correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

One can suppress Zone patching of the `onRenderReady` event in the projects manually, but it would be great to have solution working out-of-the-box. And the simplest way to fix it is to rename the event. So this PR does it.