### PR TITLE
fix(scully-plugin-puppeteer): correctly track requests in bare project

### DIFF
--- a/libs/plugins/scully-plugin-puppeteer/src/lib/plugins-scully-plugin-puppeteer.ts
+++ b/libs/plugins/scully-plugin-puppeteer/src/lib/plugins-scully-plugin-puppeteer.ts
@@ -57,13 +57,13 @@ export const puppeteerRender = async (route: HandledRoute): Promise<string> => {
       // eslint-disable-next-line no-inner-declarations
       function registerRequest(request) {
         request.continue();
-        requests.add(requests);
+        requests.add(request);
       }
 
       // eslint-disable-next-line no-inner-declarations
       function unRegisterRequest(request) {
         // request.continue();
-        requests.delete(requests);
+        requests.delete(request);
       }
 
       pageLoaded


### PR DESCRIPTION
Previously, instead of adding/removing each request from the `requests` set, the set itself was added/removed. Since `Set` deduplicates its values, it would always contain just one item (regardless of how many requests would be pending) and it would be emptied once the first request was completed.

This commit fixes this by adding/removing the actual request to/from the `requests` set.
