### PR TITLE
feat(scully): adding support for project.json with no angular.json or workspace.json

### DIFF
--- a/libs/scully/src/lib/utils/config.ts
+++ b/libs/scully/src/lib/utils/config.ts
@@ -35,14 +35,16 @@ const loadIt = async () => {
   try {
     angularConfig = readAngularJson();
     const defaultProject = compiledConfig.projectName;
-    projectConfig = angularConfig.projects[defaultProject];
+    const projectFolder = join('./apps', defaultProject);
+
+    projectConfig = angularConfig.hasOwnProperty('projects') ? angularConfig.projects[defaultProject] : projectFolder;
     const target = compiledConfig.target ? compiledConfig.target : scullyDefaults.target;
 
     if (typeof projectConfig === 'string') {
       angularConfig = readAngularJson(projectConfig);
       compiledConfig.sourceRoot = `${projectConfig}/src`;
       projectConfig = angularConfig;
-      log(`${yellow('scully')}: using project config from "${yellow(projectConfig.root)}"`);
+      log(`${yellow('scully')}: using project config from "${yellow(projectFolder)}"`);
     }
 
     distFolder = projectConfig[target].build.options.outputPath;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/scullyio/scully/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Currently, individual `project.json` files in each app are supported but scully still looks for the project path in either `workspace.json` or `angualr.json` and expects the `projects` object to exist. With the latest versions of Nx all the project configs have been migrated into the app folders and `workspace.json` & `angular.json` are removed. 

Issue Number: https://github.com/scullyio/scully/issues/1520

## What is the new behavior?

If there is no `projects` object in `angular.json` or `workspace.json`scully will then look for `project.json` is the `apps/[project]` folder.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
